### PR TITLE
Change logging from context logger to stdout + add missed stderr logging from stream logging

### DIFF
--- a/src/main/java/com/batix/rundeck/AnsibleFailureReason.java
+++ b/src/main/java/com/batix/rundeck/AnsibleFailureReason.java
@@ -5,5 +5,8 @@ import com.dtolabs.rundeck.core.execution.workflow.steps.FailureReason;
 public enum AnsibleFailureReason implements FailureReason {
   AnsibleNonZero, // Ansible process exited with non-zero value
   AnsibleError, // Ansible not found etc.
-  StorageTierAccessError
+  StorageTierAccessError,
+  Interrupted,
+  IOFailure,
+  Unknown
 }

--- a/src/main/java/com/batix/rundeck/AnsibleFileCopier.java
+++ b/src/main/java/com/batix/rundeck/AnsibleFileCopier.java
@@ -13,6 +13,7 @@ import com.dtolabs.rundeck.core.plugins.configuration.Description;
 import com.dtolabs.rundeck.core.plugins.configuration.PropertyUtil;
 import com.dtolabs.rundeck.plugins.ServiceNameConstants;
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
+import com.dtolabs.rundeck.plugins.PluginLogger;
 
 import java.io.File;
 import java.io.InputStream;
@@ -59,7 +60,9 @@ public class AnsibleFileCopier implements DestinationFileCopier, Describable {
     final INodeEntry node,
     String destinationPath
   ) throws FileCopierException {
+
     IRundeckProject project = context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject());
+
     if (destinationPath == null) {
       String identity = (context.getDataContext() != null && context.getDataContext().get("job") != null) ?
         context.getDataContext().get("job").get("execid") : null;
@@ -91,10 +94,6 @@ public class AnsibleFileCopier implements DestinationFileCopier, Describable {
       result = runner.run();
     } catch (Exception e) {
       throw new FileCopierException("Error running Ansible.", AnsibleFailureReason.AnsibleError, e);
-    }
-
-    if (result != 0) {
-      throw new FileCopierException("Ansible exited with non-zero code.", AnsibleFailureReason.AnsibleNonZero);
     }
 
     return destinationPath;

--- a/src/main/java/com/batix/rundeck/AnsibleModuleNodeStep.java
+++ b/src/main/java/com/batix/rundeck/AnsibleModuleNodeStep.java
@@ -35,7 +35,7 @@ public class AnsibleModuleNodeStep implements NodeStepPlugin, Describable {
     runner.listener(new AnsibleRunner.Listener() {
       @Override
       public void output(String line) {
-        logger.log(Project.MSG_INFO, line);
+        System.out.println(line);
       }
     });
 

--- a/src/main/java/com/batix/rundeck/AnsibleModuleNodeStep.java
+++ b/src/main/java/com/batix/rundeck/AnsibleModuleNodeStep.java
@@ -27,7 +27,7 @@ public class AnsibleModuleNodeStep implements NodeStepPlugin, Describable {
     String extraArgs = (String) configuration.get("extraArgs");
     final PluginLogger logger = context.getLogger();
 
-    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(entry.getNodename()).extraArgs(extraArgs).setLogger(logger);
+    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(entry.getNodename()).extraArgs(extraArgs);
 
     if ("true".equals(System.getProperty("ansible.debug"))) {
       runner.debug();

--- a/src/main/java/com/batix/rundeck/AnsibleModuleNodeStep.java
+++ b/src/main/java/com/batix/rundeck/AnsibleModuleNodeStep.java
@@ -27,27 +27,17 @@ public class AnsibleModuleNodeStep implements NodeStepPlugin, Describable {
     String extraArgs = (String) configuration.get("extraArgs");
     final PluginLogger logger = context.getLogger();
 
-    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(entry.getNodename()).extraArgs(extraArgs).stream();
+    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(entry.getNodename()).extraArgs(extraArgs).setLogger(logger);
+
     if ("true".equals(System.getProperty("ansible.debug"))) {
       runner.debug();
     }
-
-    runner.listener(new AnsibleRunner.Listener() {
-      @Override
-      public void output(String line) {
-        System.out.println(line);
-      }
-    });
 
     int result;
     try {
       result = runner.run();
     } catch (Exception e) {
       throw new NodeStepException("Error running Ansible.", e, AnsibleFailureReason.AnsibleError, entry.getNodename());
-    }
-
-    if (result != 0) {
-      throw new NodeStepException("Ansible exited with non-zero code.", AnsibleFailureReason.AnsibleNonZero, entry.getNodename());
     }
   }
 

--- a/src/main/java/com/batix/rundeck/AnsibleModuleWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/AnsibleModuleWorkflowStep.java
@@ -26,27 +26,16 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, Describable {
     String extraArgs = (String) configuration.get("extraArgs");
     final PluginLogger logger = context.getLogger();
 
-    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(context.getNodes()).extraArgs(extraArgs).stream();
+    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(context.getNodes()).extraArgs(extraArgs).setLogger(logger);
     if ("true".equals(System.getProperty("ansible.debug"))) {
       runner.debug();
     }
 
-    runner.listener(new AnsibleRunner.Listener() {
-      @Override
-      public void output(String line) {
-        System.out.println(line);
-      }
-    });
-
     int result;
     try {
-      result = runner.run();
+        result = runner.run();
     } catch (Exception e) {
-      throw new StepException("Error running Ansible.", e, AnsibleFailureReason.AnsibleError);
-    }
-
-    if (result != 0) {
-      throw new StepException("Ansible exited with non-zero code.", AnsibleFailureReason.AnsibleNonZero);
+        throw new StepException("Error running Ansible.", e, AnsibleFailureReason.AnsibleError);
     }
   }
 

--- a/src/main/java/com/batix/rundeck/AnsibleModuleWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/AnsibleModuleWorkflowStep.java
@@ -34,7 +34,7 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, Describable {
     runner.listener(new AnsibleRunner.Listener() {
       @Override
       public void output(String line) {
-        logger.log(Project.MSG_INFO, line);
+        System.out.println(line);
       }
     });
 

--- a/src/main/java/com/batix/rundeck/AnsibleModuleWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/AnsibleModuleWorkflowStep.java
@@ -26,7 +26,7 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, Describable {
     String extraArgs = (String) configuration.get("extraArgs");
     final PluginLogger logger = context.getLogger();
 
-    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(context.getNodes()).extraArgs(extraArgs).setLogger(logger);
+    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(context.getNodes()).extraArgs(extraArgs);
     if ("true".equals(System.getProperty("ansible.debug"))) {
       runner.debug();
     }

--- a/src/main/java/com/batix/rundeck/AnsiblePlaybookNodeStep.java
+++ b/src/main/java/com/batix/rundeck/AnsiblePlaybookNodeStep.java
@@ -59,7 +59,7 @@ public class AnsiblePlaybookNodeStep implements NodeStepPlugin, Describable {
     runner.listener(new AnsibleRunner.Listener() {
       @Override
       public void output(String line) {
-        logger.log(Project.MSG_INFO, line);
+        System.out.println(line);
       }
     });
 

--- a/src/main/java/com/batix/rundeck/AnsiblePlaybookNodeStep.java
+++ b/src/main/java/com/batix/rundeck/AnsiblePlaybookNodeStep.java
@@ -47,7 +47,7 @@ public class AnsiblePlaybookNodeStep implements NodeStepPlugin, Describable {
         vaultPass = "";
     }
 
-    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(entry.getNodename()).extraArgs(extraArgs).vaultPass(vaultPass).setLogger(logger);
+    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(entry.getNodename()).extraArgs(extraArgs).vaultPass(vaultPass);
 
     if (jobConfig.get("loglevel").equals("DEBUG")) {
       runner.debug();

--- a/src/main/java/com/batix/rundeck/AnsiblePlaybookNodeStep.java
+++ b/src/main/java/com/batix/rundeck/AnsiblePlaybookNodeStep.java
@@ -50,28 +50,18 @@ public class AnsiblePlaybookNodeStep implements NodeStepPlugin, Describable {
         vaultPass = "";
     }
 
-    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(entry.getNodename()).extraArgs(extraArgs).vaultPass(vaultPass).stream();
+    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(entry.getNodename()).extraArgs(extraArgs).vaultPass(vaultPass).setLogger(logger);
 
     if (jobConfig.get("loglevel").equals("DEBUG")) {
       runner.debug();
     }
 
-    runner.listener(new AnsibleRunner.Listener() {
-      @Override
-      public void output(String line) {
-        System.out.println(line);
-      }
-    });
-
-    int result;
     try {
-      result = runner.run();
+        runner.run();
+    } catch (AnsibleStepException e) {
+        throw new NodeStepException("Error running Ansible Node Step.", e, e.getFailureReason(), entry.getNodename());
     } catch (Exception e) {
-      throw new NodeStepException("Error running Ansible.", e, AnsibleFailureReason.AnsibleError, entry.getNodename());
-    }
-
-    if (result != 0) {
-      throw new NodeStepException("Ansible exited with non-zero code.", AnsibleFailureReason.AnsibleNonZero, entry.getNodename());
+        throw new NodeStepException(e.getMessage(), e, AnsibleFailureReason.AnsibleError, entry.getNodename());
     }
   }
 

--- a/src/main/java/com/batix/rundeck/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/AnsiblePlaybookWorkflowStep.java
@@ -46,7 +46,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, Describable {
     }
 
     // Configure the ansible runner
-    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(context.getNodes()).extraArgs(extraArgs).vaultPass(vaultPass).setLogger(logger);
+    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(context.getNodes()).extraArgs(extraArgs).vaultPass(vaultPass);
 
     // Set the logging level
     if (jobConfig.get("loglevel").equals("DEBUG")) {

--- a/src/main/java/com/batix/rundeck/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/AnsiblePlaybookWorkflowStep.java
@@ -58,7 +58,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, Describable {
     runner.listener(new AnsibleRunner.Listener() {
       @Override
       public void output(String line) {
-        logger.log(Project.MSG_INFO, line);
+        System.out.println(line);
       }
     });
 

--- a/src/main/java/com/batix/rundeck/AnsibleResourceModelSource.java
+++ b/src/main/java/com/batix/rundeck/AnsibleResourceModelSource.java
@@ -68,9 +68,6 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
 
     try {
       int status = runner.run();
-      if (status != 0) {
-        System.out.println("error gathering facts:\n" + runner.getOutput());
-      }
     } catch (Exception e) {
       throw new ResourceModelSourceException("Error running playbook.", e);
     }

--- a/src/main/java/com/batix/rundeck/AnsibleRunner.java
+++ b/src/main/java/com/batix/rundeck/AnsibleRunner.java
@@ -272,18 +272,21 @@ class AnsibleRunner {
       .command(procArgs)
       .directory(tempDirectory.toFile()); // set cwd
     File outputFile = null;
+
+    // redirect stderr to stdout
+    processBuilder.redirectErrorStream(true);
+
     if (!stream) {
       outputFile = File.createTempFile("ansible-runner", "output");
       processBuilder
-        .redirectErrorStream(true) // redirect stderr to stdout
         .redirectOutput(outputFile); // redirect to file, stream might block on too much output
     }
     Process proc = processBuilder.start();
 
     if (stream) {
-      InputStream stdout = proc.getInputStream();
-      InputStreamReader in = new InputStreamReader(stdout);
+      InputStreamReader in = new InputStreamReader( proc.getInputStream() );
       LineNumberReader lines = new LineNumberReader(in);
+
       String line;
       StringBuilder sb = new StringBuilder();
       while ((line = lines.readLine()) != null) {
@@ -334,7 +337,6 @@ class AnsibleRunner {
         }
       });
     }
-
     return result;
   }
 

--- a/src/main/java/com/batix/rundeck/AnsibleStepException.java
+++ b/src/main/java/com/batix/rundeck/AnsibleStepException.java
@@ -1,0 +1,24 @@
+package com.batix.rundeck;
+
+public class AnsibleStepException extends Exception {
+    protected AnsibleFailureReason failureReason;
+
+    public AnsibleStepException(String msg, AnsibleFailureReason reason) {
+        super(msg);
+        this.failureReason = reason;
+    }
+
+    public AnsibleStepException(Throwable cause, AnsibleFailureReason reason) {
+        super(cause);
+        this.failureReason = reason;
+    }
+
+    public AnsibleStepException(String msg, Throwable cause, AnsibleFailureReason reason) {
+        super(msg, cause);
+        this.failureReason = reason;
+    }
+
+    public AnsibleFailureReason getFailureReason() {
+        return failureReason;
+    }
+}

--- a/src/main/java/com/batix/rundeck/utils/Listener.java
+++ b/src/main/java/com/batix/rundeck/utils/Listener.java
@@ -1,0 +1,7 @@
+package com.batix.rundeck.utils;
+
+public interface Listener {
+
+      void output(String line);
+
+}

--- a/src/main/java/com/batix/rundeck/utils/ListenerFactory.java
+++ b/src/main/java/com/batix/rundeck/utils/ListenerFactory.java
@@ -1,0 +1,15 @@
+package com.batix.rundeck.utils;
+
+import java.io.*;
+
+public abstract class ListenerFactory {
+
+      public static Listener getListener(final PrintStream stream) {            
+        return new Listener() {
+                @Override
+                public void output(String line) {
+                    stream.println(line);
+                }
+              };
+      }
+}

--- a/src/main/java/com/batix/rundeck/utils/Logging.java
+++ b/src/main/java/com/batix/rundeck/utils/Logging.java
@@ -1,0 +1,69 @@
+/**
+ * Logging utility class for reading and parsing ansible logs
+ *
+ * @author Yassine Azzouz <a href="mailto:yassine.azzouz@gmail.com">yassine.azzouz@gmail.com</a>
+ */
+package com.batix.rundeck.utils;
+
+import java.io.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class Logging {
+
+   /**
+    * A simple Thread subclass that perform realtime ansible logging.
+    */ 
+    public static class AnsibleLoggerThread extends Thread { 
+        final InputStream in; 
+        final Listener out; 
+        private IOException exception; 
+ 
+        public AnsibleLoggerThread(final InputStream in, final Listener out) { 
+            this.in = in; 
+            this.out = out; 
+        } 
+ 
+        @Override 
+        public void run() { 
+            try { 
+                Logging.ansibleStreamLogger(in, out); 
+            } catch (IOException e) { 
+                exception = e; 
+            } 
+        } 
+ 
+        public IOException getException() { 
+            return exception; 
+        }
+    }
+    
+   /**
+    * Read the ansible logs from the input stream then parse and try to return it to the output listener. 
+    * 
+    * @param in  inputstream 
+    * @param out listener 
+    * 
+    * @throws java.io.IOException if thrown by underlying io operations 
+    */
+    public static void ansibleStreamLogger(final InputStream in, final Listener out) throws IOException { 
+       InputStreamReader isr = new InputStreamReader(in);
+       LineNumberReader lines = new LineNumberReader(isr);
+       String line;
+       while ((line = lines.readLine()) != null) {
+         out.output(line);
+       }
+    }
+
+    /**
+     * Return a new thread that will copy an inputstream to an output stream.  You must start the thread. 
+     * 
+     * @param in  inputstream 
+     * @param out listener 
+     * 
+     * @return an unstarted {@link AnsibleLoggerThread} 
+     */ 
+    public static AnsibleLoggerThread copyStreamThread(final InputStream in, final Listener out) { 
+        return new AnsibleLoggerThread(in, out); 
+    }
+}


### PR DESCRIPTION
Hi @frozenice ,

I found out that the errors are not displayed in stream logs if the ansible playbook fails, so I added a redirection so that stderr get redirected to stdout for stream logging just like file logging. I also changed the logging from context logger to to stdout, I thought this will be better since the context logger will print ansible output in rendeck.log too so it will print lot of logs and make debugging a bit difficult, whereas stdout will print logs only in the screen. 

Please let me know your thoughts,
Thanks,  
