### PR TITLE
Added support for ansible's -k or --ask-pass option.

### DIFF
--- a/src/main/java/com/batix/rundeck/AnsibleModuleNodeStep.java
+++ b/src/main/java/com/batix/rundeck/AnsibleModuleNodeStep.java
@@ -25,9 +25,11 @@ public class AnsibleModuleNodeStep implements NodeStepPlugin, Describable {
     String module = (String) configuration.get("module");
     String args = (String) configuration.get("args");
     String extraArgs = (String) configuration.get("extraArgs");
+    Map<java.lang.String,java.lang.String> privateOptionConfig = context.getExecutionContext().getPrivateDataContext().get("option");
+    String sshPass = (String) privateOptionConfig.get("sshPassword");
     final PluginLogger logger = context.getLogger();
 
-    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(entry.getNodename()).extraArgs(extraArgs).stream();
+    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(entry.getNodename()).extraArgs(extraArgs).sshPass(sshPass).stream();
     if ("true".equals(System.getProperty("ansible.debug"))) {
       runner.debug();
     }

--- a/src/main/java/com/batix/rundeck/AnsibleModuleWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/AnsibleModuleWorkflowStep.java
@@ -24,9 +24,11 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, Describable {
     String module = (String) configuration.get("module");
     String args = (String) configuration.get("args");
     String extraArgs = (String) configuration.get("extraArgs");
+    Map<java.lang.String,java.lang.String> privateOptionConfig = context.getExecutionContext().getPrivateDataContext().get("option");
+    String sshPass = (String) privateOptionConfig.get("sshPassword");
     final PluginLogger logger = context.getLogger();
 
-    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(context.getNodes()).extraArgs(extraArgs).stream();
+    AnsibleRunner runner = AnsibleRunner.adHoc(module, args).limit(context.getNodes()).extraArgs(extraArgs).sshPass(sshPass).stream();
     if ("true".equals(System.getProperty("ansible.debug"))) {
       runner.debug();
     }

--- a/src/main/java/com/batix/rundeck/AnsiblePlaybookNodeStep.java
+++ b/src/main/java/com/batix/rundeck/AnsiblePlaybookNodeStep.java
@@ -30,6 +30,8 @@ public class AnsiblePlaybookNodeStep implements NodeStepPlugin, Describable {
     String playbook = (String) configuration.get("playbook");
     String extraArgs = (String) configuration.get("extraArgs");
     String vaultPass = (String) configuration.get("vaultPass");
+    Map<java.lang.String,java.lang.String> privateOptionConfig = context.getExecutionContext().getPrivateDataContext().get("option");
+    String sshPass = (String) privateOptionConfig.get("sshPassword");
 
     final PluginLogger logger = context.getLogger();
     Map<java.lang.String,java.lang.String> jobConfig = context.getDataContext().get("job");
@@ -47,7 +49,7 @@ public class AnsiblePlaybookNodeStep implements NodeStepPlugin, Describable {
         vaultPass = "";
     }
 
-    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(entry.getNodename()).extraArgs(extraArgs).vaultPass(vaultPass).stream();
+    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(entry.getNodename()).extraArgs(extraArgs).vaultPass(vaultPass).sshPass(sshPass).stream();
 
     if (jobConfig.get("loglevel").equals("DEBUG")) {
       runner.debug();

--- a/src/main/java/com/batix/rundeck/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/AnsiblePlaybookWorkflowStep.java
@@ -28,6 +28,8 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, Describable {
     String playbook = (String) configuration.get("playbook");
     String extraArgs = (String) configuration.get("extraArgs");
     String vaultPass = (String) configuration.get("vaultPass");
+    Map<java.lang.String,java.lang.String> privateOptionConfig = context.getExecutionContext().getPrivateDataContext().get("option");
+    String sshPass = (String) privateOptionConfig.get("sshPassword");
 
     final PluginLogger logger = context.getLogger();
     Map<java.lang.String,java.lang.String> jobConfig = context.getDataContext().get("job");
@@ -45,7 +47,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, Describable {
         vaultPass = "";
     }
 
-    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(context.getNodes()).extraArgs(extraArgs).vaultPass(vaultPass).stream();
+    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(context.getNodes()).extraArgs(extraArgs).vaultPass(vaultPass).sshPass(sshPass).stream();
 
     if (jobConfig.get("loglevel").equals("DEBUG")) {
       runner.debug();

--- a/src/main/java/com/batix/rundeck/AnsibleRunner.java
+++ b/src/main/java/com/batix/rundeck/AnsibleRunner.java
@@ -71,6 +71,7 @@ class AnsibleRunner {
   private String arg;
   private String extraArgs;
   private String vaultPass;
+  private String sshPass;
   private String playbook;
   private boolean debug;
   private Path tempDirectory;
@@ -102,6 +103,13 @@ class AnsibleRunner {
   public AnsibleRunner extraArgs(String args) {
     if (args != null && args.length() > 0) {
       extraArgs = args;
+    }
+    return this;
+  }
+
+  public AnsibleRunner sshPass(String pass) {
+    if (pass != null && pass.length() > 0) {
+      sshPass = pass;
     }
     return this;
   }
@@ -279,6 +287,13 @@ class AnsibleRunner {
         .redirectOutput(outputFile); // redirect to file, stream might block on too much output
     }
     Process proc = processBuilder.start();
+
+    if ((tokenizeCommand(extraArgs).contains("-k") || tokenizeCommand(extraArgs).contains("--ask-pass")) && (sshPass != null && sshPass.length() > 0)) {
+      OutputStream stdin = proc.getOutputStream();
+      OutputStreamWriter out = new OutputStreamWriter(stdin);
+      out.write(sshPass+"\n");
+      out.close();
+    }
 
     if (stream) {
       InputStream stdout = proc.getInputStream();


### PR DESCRIPTION
In my setup I don't want to have a generic account on every host that has "sudo all" and in order to have some accountability I want everybody on the team to use their personal user accounts (that have "sudo all") when running modules or playbooks. This implies that in the rundeck GUI the user must be prompted for his credentials and those credentials passed to ansible with the -k option.

I've added support for passing the -k or --ask-pass option in the extra arguments box of rundeck jobs. A job option named "sshPassword" must be created as Secure Remote Authentication.

As an example I have 2 job options defined:
- sshUser
- sshPassword
  And I have in the extra arguments box something like:
- "-u ${option.sshUser} -k"

I'm not a java developper, I'm just a sysadmin :), but I tried to keep it as simple as possible and using the same naming conventions (there is probably a much better way to do this ;)).

If you find it to be useful, please include it.

Tks
