### PR TITLE
Pass rundeck options as environment variables to ansible

### DIFF
--- a/src/main/java/com/batix/rundeck/AnsiblePlaybookNodeStep.java
+++ b/src/main/java/com/batix/rundeck/AnsiblePlaybookNodeStep.java
@@ -33,6 +33,7 @@ public class AnsiblePlaybookNodeStep implements NodeStepPlugin, Describable {
     String sshPass = (String) configuration.get("sshPassword");
     final PluginLogger logger = context.getLogger();
     Map<java.lang.String,java.lang.String> jobConfig = context.getDataContext().get("job");
+    Map<String,String> options = context.getDataContext().get("option");
 
     if (vaultPass != null && vaultPass.length() > 0) {
         Resource<ResourceMeta> resource  = context.getExecutionContext().getStorageTree().getResource(vaultPass);
@@ -47,7 +48,7 @@ public class AnsiblePlaybookNodeStep implements NodeStepPlugin, Describable {
         vaultPass = "";
     }
 
-    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(entry.getNodename()).extraArgs(extraArgs).vaultPass(vaultPass).sshPass(sshPass);
+    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(entry.getNodename()).extraArgs(extraArgs).vaultPass(vaultPass).sshPass(sshPass).options(options);
 
     if (jobConfig.get("loglevel").equals("DEBUG")) {
       runner.debug();

--- a/src/main/java/com/batix/rundeck/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/AnsiblePlaybookWorkflowStep.java
@@ -31,6 +31,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, Describable {
     String sshPass = (String) configuration.get("sshPassword");
     final PluginLogger logger = context.getLogger();
     Map<java.lang.String,java.lang.String> jobConfig = context.getDataContext().get("job");
+    Map<String,String> options = context.getDataContext().get("option");
 
     if (vaultPass != null && vaultPass.length() > 0) {
         Resource<ResourceMeta> resource  = context.getExecutionContext().getStorageTree().getResource(vaultPass);
@@ -46,7 +47,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, Describable {
     }
 
     // Configure the ansible runner
-    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(context.getNodes()).extraArgs(extraArgs).vaultPass(vaultPass).sshPass(sshPass);
+    AnsibleRunner runner = AnsibleRunner.playbook(playbook).limit(context.getNodes()).extraArgs(extraArgs).vaultPass(vaultPass).sshPass(sshPass).options(options);
 
     // Set the logging level
     if (jobConfig.get("loglevel").equals("DEBUG")) {

--- a/src/main/java/com/batix/rundeck/AnsibleRunner.java
+++ b/src/main/java/com/batix/rundeck/AnsibleRunner.java
@@ -15,6 +15,8 @@ import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 
 class AnsibleRunner {
 
@@ -70,6 +72,7 @@ class AnsibleRunner {
   private boolean retainTempDirectory;
   private final List<String> limits = new ArrayList<>();
   private int result;
+  private Map<String, String> options = new HashMap<>();
 
   private Listener listener;
 
@@ -166,6 +169,14 @@ class AnsibleRunner {
     return this;
   }
 
+  /**
+   * Add options passed as Environment variables to ansible
+   */
+  public AnsibleRunner options(Map<String, String> options) {
+    this.options.putAll(options);
+    return this;
+  }
+
   public void deleteTempDirectory(Path tempDirectory) throws IOException {
       Files.walkFileTree(tempDirectory, new SimpleFileVisitor<Path>() {
         @Override
@@ -259,6 +270,12 @@ class AnsibleRunner {
     ProcessBuilder processBuilder = new ProcessBuilder()
       .command(procArgs)
       .directory(tempDirectory.toFile()); // set cwd
+    Map<String, String> processEnvironment = processBuilder.environment();
+    
+    Map<String, String> globalEnvironment = System.getenv();
+    for (String optionName : this.options.keySet()) {
+        processEnvironment.put(optionName, this.options.get(optionName));
+    }
     Process proc = null;
 
     try {


### PR DESCRIPTION
This add the possibility to pass the options of the jobs to ansible as environment variables (can be used with lookup('env','option_name').
It could be usefull for passing password without showing the in logs (mandatory in some network modules, ios_command for instance).
