### PR TITLE
Fixing Extra Arguments parsing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ configurations {
 
 dependencies {
   pluginLibs 'com.google.code.gson:gson:2.5'
-
   compile 'org.rundeck:rundeck-core:2.6.3'
 }
 

--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -177,13 +177,13 @@ public interface AnsibleDescribable extends Describable {
             .title("Extra Variables")
             .description("Set additional playbook YAML or JSON variables.")
             .renderingOption(StringRenderingConstants.DISPLAY_TYPE_KEY,
-                    StringRenderingConstants.DisplayType.CODE)
+                    StringRenderingConstants.DisplayType.MULTI_LINE)
             .build();
     
     public static Property EXTRA_ATTRS_PROP = PropertyUtil.string(
             ANSIBLE_EXTRA_PARAM,
-            "Extra Ansible paramters",
-            "Set additional raw ansible parameters.",
+            "Extra Ansible arguments",
+            "Additional ansible raw command line arguments to be appended to the executed command.",
             false,
             ""
       );

--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -74,6 +74,7 @@ public interface AnsibleDescribable extends Describable {
     public static final String ANSIBLE_LIMIT = "ansible-limit";
     public static final String ANSIBLE_IGNORE_TAGS = "ansible-ignore-tags-prefix";
     public static final String ANSIBLE_EXTRA_VARS = "ansible-extra-vars";
+    public static final String ANSIBLE_EXTRA_PARAM = "ansible-extra-param";
     public static final String ANSIBLE_VAULT_PATH = "ansible-vault-path";
     public static final String ANSIBLE_VAULTSTORE_PATH = "ansible-vault-storage-path";
 
@@ -127,8 +128,7 @@ public interface AnsibleDescribable extends Describable {
     );
 
     public static Property INVENTORY_PROP = PropertyUtil.string(ANSIBLE_INVENTORY, "ansible inventory File path",
-            "File Path to the ansible inventory to use",
-            false, null);
+            "File Path to the ansible inventory to use", false, null);
 
     public static Property EXECUTABLE_PROP = PropertyUtil.freeSelect(
               ANSIBLE_EXECUTABLE,
@@ -171,14 +171,23 @@ public interface AnsibleDescribable extends Describable {
               ""
     );
 
-    public static Property EXTRA_VARS_PROP = PropertyUtil.string(
-          ANSIBLE_EXTRA_VARS,
-          "Extra Variables",
-          "Set additional variables as key=value or YAML/JSON",
-          false,
-          null
-    );
-
+    static final Property EXTRA_VARS_PROP = PropertyBuilder.builder()
+            .string(ANSIBLE_EXTRA_VARS)
+            .required(false)
+            .title("Extra Variables")
+            .description("Set additional playbook YAML or JSON variables.")
+            .renderingOption(StringRenderingConstants.DISPLAY_TYPE_KEY,
+                    StringRenderingConstants.DisplayType.CODE)
+            .build();
+    
+    public static Property EXTRA_ATTRS_PROP = PropertyUtil.string(
+            ANSIBLE_EXTRA_PARAM,
+            "Extra Ansible paramters",
+            "Set additional raw ansible parameters.",
+            false,
+            ""
+      );
+    
     static final Property VAULT_KEY_FILE_PROP = PropertyUtil.string(ANSIBLE_VAULT_PATH, "Vault Key File path",
             "File Path to the ansible vault Key to use",
             false, null);

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
@@ -466,9 +466,8 @@ public class AnsibleRunner {
         // Make sure to always cleanup on failure and success
         proc.getErrorStream().close();
         proc.getInputStream().close();
-        if (proc.isAlive()) {
-        	proc.destroy();
-        }
+        proc.destroy();
+
         if (tempFile != null && !tempFile.delete()) {
           tempFile.deleteOnExit();
         }

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
@@ -722,7 +722,7 @@ public class AnsibleRunnerBuilder {
 
         String extraVars = getExtraVars();
         if (extraVars != null) {
-            runner = runner.extraArgs(extraVars);
+            runner = runner.extraVars(extraVars);
         }
         
         String user = getSshUser();

--- a/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookWorkflowStep.java
@@ -30,6 +30,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
 
         builder.property(PLAYBOOK_PROP);
         builder.property(EXTRA_VARS_PROP);
+        builder.property(EXTRA_ATTRS_PROP);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);
         builder.property(SSH_AUTH_TYPE_PROP);

--- a/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookWorkflowStep.java
@@ -30,9 +30,9 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
 
         builder.property(PLAYBOOK_PROP);
         builder.property(EXTRA_VARS_PROP);
-        builder.property(EXTRA_ATTRS_PROP);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);
+        builder.property(EXTRA_ATTRS_PROP);
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(SSH_USER_PROP);
         builder.property(SSH_PASSWORD_STORAGE_PROP);

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
@@ -207,9 +207,14 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
     runner.tempDirectory(tempDirectory).retainTempDirectory();
 
     StringBuilder args = new StringBuilder();
-    args.append("facts=").append(gatherFacts ? "True" : "False");
-    args.append(" ").append("tmpdir='").append(tempDirectory.toFile().getAbsolutePath()).append("'");
-    runner.extraArgs(args.toString());
+    args.append("facts: ")
+        .append(gatherFacts ? "True" : "False")
+        .append("\n")
+        .append("tmpdir: '")
+        .append(tempDirectory.toFile().getAbsolutePath())
+        .append("'");
+    
+    runner.extraVars(args.toString());
 
     try {
         runner.run();

--- a/src/main/java/com/batix/rundeck/utils/ArgumentTokenizer.java
+++ b/src/main/java/com/batix/rundeck/utils/ArgumentTokenizer.java
@@ -115,27 +115,6 @@ public abstract class ArgumentTokenizer {
               currArg.append(c);
             }
             break;
-//          case NORMAL_TOKEN_STATE:
-//            if (Character.isWhitespace(c)) {
-//              // Whitespace ends the token; start a new one
-//              argList.add(currArg.toString());
-//              currArg = new StringBuffer();
-//              state = NO_TOKEN_STATE;
-//            }
-//            else if (c == '\\') {
-//              // Backslash in a normal token: escape the next character
-//              escaped = true;
-//            }
-//            else if (c == '\'') {
-//              state = SINGLE_QUOTE_STATE;
-//            }
-//            else if (c == '"') {
-//              state = DOUBLE_QUOTE_STATE;
-//            }
-//            else {
-//              currArg.append(c);
-//            }
-//            break;
           case NO_TOKEN_STATE:
           case NORMAL_TOKEN_STATE:
             switch(c) {


### PR DESCRIPTION
- Using multi-line extra arguments in YAML/JSON format to be able to parse variable types, the current way extra variable are handled is by appending them to the cmd using key=value syntax which cause lot of quoting issues and force all variables to be interpreted as strings in ansible [http://docs.ansible.com/ansible/playbooks_variables.html](url) : 

> Values passed in using the key=value syntax are interpreted as strings. Use the JSON format if you need to pass in anything that shouldn’t be a string (Booleans, integers, floats, lists etc).
- Restoring Extra cmd arguments parameters as it could be useful in some use cases
- Fixing Cleanup on failure, to make sure the ansible process is killed when the parent process is killed or interrupted.
