### PR TITLE
Run commands and scripts to windows hosts

### DIFF
--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -14,7 +14,7 @@ public interface AnsibleDescribable extends Describable {
     public static enum Executable {
         bash("/bin/bash"),
         sh("/bin/sh");
-    	
+
     	private final String executable;
     	
     	Executable(String executable) {
@@ -32,6 +32,29 @@ public interface AnsibleDescribable extends Describable {
     	    }
     	    return list.toArray(new String[list.size()]);
     	}
+    }
+
+    public static enum WindowsExecutable {
+        cmd("cmd.exe"),
+        powershell("powershell.exe");
+
+        private final String executable;
+
+        WindowsExecutable(String executable) {
+            this.executable = executable;
+        }
+
+        public String getValue() {
+            return executable;
+        }
+
+        public static String[] getValues() {
+            java.util.LinkedList<String> list = new LinkedList<String>();
+            for (WindowsExecutable s : WindowsExecutable.values()) {
+                list.add(s.executable);
+            }
+            return list.toArray(new String[list.size()]);
+        }
     }
 
     public static enum AuthenticationType {
@@ -68,7 +91,9 @@ public interface AnsibleDescribable extends Describable {
     public static final String ANSIBLE_MODULE_ARGS = "ansible-module-args";
     public static final String ANSIBLE_DEBUG = "ansible-debug";
     public static final String ANSIBLE_EXECUTABLE = "ansible-executable";
+    public static final String ANSIBLE_WINDOWS_EXECUTABLE = "ansible-windows-executable";
     public static final String DEFAULT_ANSIBLE_EXECUTABLE = "/bin/sh";
+    public static final String DEFAULT_ANSIBLE_WINDOWS_EXECUTABLE = "powershell.exe";
     public static final String ANSIBLE_GATHER_FACTS = "ansible-gather-facts";
     public static final String ANSIBLE_IGNORE_ERRORS = "ansible-ignore-errors";
     public static final String ANSIBLE_EXTRA_TAG = "ansible-extra-tag";
@@ -138,6 +163,15 @@ public interface AnsibleDescribable extends Describable {
               true,
               null,
               Arrays.asList(Executable.getValues())
+    );
+
+    public static Property WINDOWS_EXECUTABLE_PROP = PropertyUtil.freeSelect(
+            ANSIBLE_WINDOWS_EXECUTABLE,
+            "Windows Executable",
+            "Change the remote shell used to execute the command on Windows Remote Nodes. Should be an absolute path to the executable.",
+            false,
+            null,
+            Arrays.asList(WindowsExecutable.getValues())
     );
 
     public static Property GATHER_FACTS_PROP = PropertyUtil.bool(

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleFileCopier.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleFileCopier.java
@@ -87,6 +87,9 @@ public class AnsibleFileCopier implements DestinationFileCopier, AnsibleDescriba
 
     AnsibleRunner runner = null;
 
+    //check if the node is a windows host
+    boolean windows=node.getAttributes().get("osFamily").toLowerCase().contains("windows");
+
     IRundeckProject project = context.getFramework().getFrameworkProjectMgr().getFrameworkProject(context.getFrameworkProject());
 
     if (destinationPath == null) {
@@ -109,7 +112,13 @@ public class AnsibleFileCopier implements DestinationFileCopier, AnsibleDescriba
     String cmdArgs = "src='" + localTempFile.getAbsolutePath() + "' dest='" + destinationPath + "'";
 
     Map<String, Object> jobConf = new HashMap<String, Object>();
-    jobConf.put(AnsibleDescribable.ANSIBLE_MODULE,"copy");
+
+    if(windows){
+        jobConf.put(AnsibleDescribable.ANSIBLE_MODULE,"win_copy");
+    }else{
+        jobConf.put(AnsibleDescribable.ANSIBLE_MODULE,"copy");
+    }
+
     jobConf.put(AnsibleDescribable.ANSIBLE_MODULE_ARGS,cmdArgs.toString());
     jobConf.put(AnsibleDescribable.ANSIBLE_LIMIT,node.getNodename());
 

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleNodeExecutor.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleNodeExecutor.java
@@ -32,6 +32,7 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
         builder.title("Ansible Ad-Hoc Node Executor");
         builder.description("Runs Ansible Ad-Hoc commands on the nodes using the shell module.");
         builder.property(EXECUTABLE_PROP);
+        builder.property(WINDOWS_EXECUTABLE_PROP);
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(SSH_USER_PROP);
         builder.property(SSH_PASSWORD_STORAGE_PROP);
@@ -44,6 +45,8 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
         builder.mapping(ANSIBLE_EXECUTABLE,PROJ_PROP_PREFIX + ANSIBLE_EXECUTABLE);
         builder.frameworkMapping(ANSIBLE_EXECUTABLE,FWK_PROP_PREFIX + ANSIBLE_EXECUTABLE);
+        builder.mapping(ANSIBLE_WINDOWS_EXECUTABLE,PROJ_PROP_PREFIX + ANSIBLE_WINDOWS_EXECUTABLE);
+        builder.frameworkMapping(ANSIBLE_WINDOWS_EXECUTABLE,FWK_PROP_PREFIX + ANSIBLE_WINDOWS_EXECUTABLE);
         builder.mapping(ANSIBLE_SSH_AUTH_TYPE,PROJ_PROP_PREFIX + ANSIBLE_SSH_AUTH_TYPE);
         builder.frameworkMapping(ANSIBLE_SSH_AUTH_TYPE,FWK_PROP_PREFIX + ANSIBLE_SSH_AUTH_TYPE);
         builder.mapping(ANSIBLE_SSH_USER,PROJ_PROP_PREFIX + ANSIBLE_SSH_USER);
@@ -87,8 +90,19 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
                           null
                         );
 
+    //windows executable
+    String windowsExecutable = PropertyResolver.resolveProperty(
+                                      AnsibleDescribable.ANSIBLE_WINDOWS_EXECUTABLE,
+                                      AnsibleDescribable.DEFAULT_ANSIBLE_WINDOWS_EXECUTABLE,
+                                      context.getFrameworkProject(),
+                                      context.getFramework(),
+                                      node,
+                                      null
+                              );
+
+
     if(windows) {
-        //if is a windows host, not add the executable
+        cmdArgs.append("executable=").append(windowsExecutable);
         for (String cmd : command) {
             cmdArgs.append(" ").append(cmd).append("");
         }
@@ -97,7 +111,6 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
         for (String cmd : command) {
             cmdArgs.append(" '").append(cmd).append("'");
         }
-
     }
 
 

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
@@ -239,10 +239,14 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
           JsonObject root = json.getAsJsonObject();
 
           String hostname = root.get("inventory_hostname").getAsString();
-          if (root.has("ansible_host")) {
-            hostname = root.get("ansible_host").getAsString();
-          } else if (root.has("ansible_ssh_host")) { // deprecated variable
-            hostname = root.get("ansible_ssh_host").getAsString();
+          try {
+            if (root.has("ansible_host")) {
+              hostname = root.get("ansible_host").getAsString();
+            } else if (root.has("ansible_ssh_host")) { // deprecated variable
+              hostname = root.get("ansible_ssh_host").getAsString();
+            }
+          }catch(Exception ex){
+            System.out.println("[warn] Problem getting the ansible_host attribute from node " + hostname);
           }
 
           String nodename = root.get("inventory_hostname").getAsString();

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
@@ -294,12 +294,12 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
           // ansible_system     = Linux   = osFamily in Rundeck
           // ansible_os_family  = Debian  = osName in Rundeck
 
-          if (root.has("ansible_system")) {
-            node.setOsFamily(root.get("ansible_system").getAsString());
+          if (root.has("ansible_os_family")) {
+            node.setOsFamily(root.get("ansible_os_family").getAsString());
           }
 
-          if (root.has("ansible_os_family")) {
-            node.setOsName(root.get("ansible_os_family").getAsString());
+          if (root.has("ansible_os_name")) {
+            node.setOsName(root.get("ansible_os_name").getAsString());
           }
 
           if (root.has("ansible_architecture")) {


### PR DESCRIPTION
Add option to run commands, scripts (Node Executor and File Copier) to windows hosts, it required winrm support on the ansible server (see http://docs.ansible.com/ansible/intro_windows.html)

Also, fix an issue getting the nodes form Ansible when the host has defined the attribute ansible_host equal to null

