### PR TITLE
Debug change, removed default verbosity. (AnsibleRunner.java)

### DIFF
--- a/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
@@ -346,11 +346,8 @@ public class AnsibleRunner {
     }
 
     if (debug == Boolean.TRUE) {
-      procArgs.add("-vvvv");
-    } else {
-      procArgs.add("-v");
+      procArgs.add("-vvv");
     }
-
 
     if (extraVars != null && extraVars.length() > 0) {
     	tempVarsFile = File.createTempFile("ansible-runner", "extra-vars");


### PR DESCRIPTION
Line 348: Removed else statement that sets default verbose from debug function. 

This is in reference to Issue #98 

Also changed debug level 4 to debug level 3. A level 4 in Rundeck may cause log output to crash. If debug level 4 is needed that should be done at the CLI.