### PR TITLE
Set ansible config path per Project on Resource Model, Node Executor and File Copier

### DIFF
--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -127,6 +127,9 @@ public interface AnsibleDescribable extends Describable {
     public static final String ANSIBLE_BECOME_PASSWORD_STORAGE_PATH = "ansible-become-password-storage-path";
     public static final String DEFAULT_ANSIBLE_BECOME_PASSWORD_OPTION = "ansible-become-password";
 
+
+    public static final String ANSIBLE_CONFIG_FILE_PATH = "ansible-config-file-path";
+
     public static final String PROJ_PROP_PREFIX = "project.";
     public static final String FWK_PROP_PREFIX = "framework.";
 
@@ -395,6 +398,13 @@ public interface AnsibleDescribable extends Describable {
             .values(Arrays.asList(BecomeMethodType.getValues()))
             .renderingOption(StringRenderingConstants.GROUPING,"SECONDARY")
             .renderingOption(StringRenderingConstants.GROUP_NAME,"Privilege Escalation")
+            .build();
+
+    static final Property CONFIG_FILE_PATH = PropertyBuilder.builder()
+            .string(ANSIBLE_CONFIG_FILE_PATH)
+            .required(false)
+            .title("Ansible config file path")
+            .description("Set ansible config file path.")
             .build();
 
 }

--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -169,7 +169,7 @@ public interface AnsibleDescribable extends Describable {
     );
 
     public static Property INVENTORY_PROP = PropertyUtil.string(ANSIBLE_INVENTORY, "ansible inventory File path",
-            "File Path to the ansible inventory to use", false, null);
+            "File Path to the ansible inventory to use, It can be blank if \"Ansible config file path\" is set  ", false, null);
 
     public static Property EXECUTABLE_PROP = PropertyUtil.freeSelect(
               ANSIBLE_EXECUTABLE,

--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -126,6 +126,9 @@ public interface AnsibleDescribable extends Describable {
     public static final String ANSIBLE_BECOME_PASSWORD_STORAGE_PATH = "ansible-become-password-storage-path";
     public static final String DEFAULT_ANSIBLE_BECOME_PASSWORD_OPTION = "ansible-become-password";
 
+
+    public static final String ANSIBLE_CONFIG_FILE_PATH = "ansible-config-file-path";
+
     public static final String PROJ_PROP_PREFIX = "project.";
     public static final String FWK_PROP_PREFIX = "framework.";
 
@@ -374,6 +377,13 @@ public interface AnsibleDescribable extends Describable {
             .values(Arrays.asList(BecomeMethodType.getValues()))
             .renderingOption(StringRenderingConstants.GROUPING,"SECONDARY")
             .renderingOption(StringRenderingConstants.GROUP_NAME,"Privilege Escalation")
+            .build();
+
+    static final Property CONFIG_FILE_PATH = PropertyBuilder.builder()
+            .string(ANSIBLE_CONFIG_FILE_PATH)
+            .required(false)
+            .title("Ansible config file path")
+            .description("Set ansible config file path.")
             .build();
 
 }

--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -157,7 +157,7 @@ public interface AnsibleDescribable extends Describable {
     );
 
     public static Property INVENTORY_PROP = PropertyUtil.string(ANSIBLE_INVENTORY, "ansible inventory File path",
-            "File Path to the ansible inventory to use", false, null);
+            "File Path to the ansible inventory to use, It can be blank if \"Ansible config file path\" is set  ", false, null);
 
     public static Property EXECUTABLE_PROP = PropertyUtil.freeSelect(
               ANSIBLE_EXECUTABLE,

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
@@ -93,6 +93,8 @@ public class AnsibleRunner {
   private int result;
   private Map<String, String> options = new HashMap<>();
 
+  protected String configFile;
+
   private Listener listener;
 
   private AnsibleRunner(AnsibleCommand type) {
@@ -221,6 +223,13 @@ public class AnsibleRunner {
   public AnsibleRunner becomePassword(String pass) {
     if (pass != null && pass.length() > 0) {
       becomePassword = pass;
+    }
+    return this;
+  }
+
+  public AnsibleRunner configFile(String path) {
+    if (path != null && path.length() > 0) {
+      configFile = path;
     }
     return this;
   }
@@ -423,7 +432,15 @@ public class AnsibleRunner {
     Process proc = null;
 
     Map<String, String> processEnvironment = processBuilder.environment();
-    
+
+    if (configFile != null && configFile.length() > 0) {
+      if (debug) {
+        System.out.println(" ANSIBLE_CONFIG: "+configFile);
+      }
+
+      processEnvironment.put("ANSIBLE_CONFIG", configFile);
+    }
+
     for (String optionName : this.options.keySet()) {
         processEnvironment.put(optionName, this.options.get(optionName));
     }

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
@@ -100,6 +100,8 @@ public class AnsibleRunner {
   private int result;
   private Map<String, String> options = new HashMap<>();
 
+  protected String configFile;
+
   private Listener listener;
 
   private AnsibleRunner(AnsibleCommand type) {
@@ -228,6 +230,13 @@ public class AnsibleRunner {
   public AnsibleRunner becomePassword(String pass) {
     if (pass != null && pass.length() > 0) {
       becomePassword = pass;
+    }
+    return this;
+  }
+
+  public AnsibleRunner configFile(String path) {
+    if (path != null && path.length() > 0) {
+      configFile = path;
     }
     return this;
   }
@@ -434,6 +443,14 @@ public class AnsibleRunner {
     Process proc = null;
 
     Map<String, String> processEnvironment = processBuilder.environment();
+
+    if (configFile != null && configFile.length() > 0) {
+      if (debug) {
+        System.out.println(" ANSIBLE_CONFIG: "+configFile);
+      }
+
+      processEnvironment.put("ANSIBLE_CONFIG", configFile);
+    }
 
     for (String optionName : this.options.keySet()) {
         processEnvironment.put(optionName, this.options.get(optionName));

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
@@ -690,6 +690,25 @@ public class AnsibleRunnerBuilder {
         }
         return limit;
     }
+
+    public String getConfigFile() {
+
+        final String configFile;
+        configFile = PropertyResolver.resolveProperty(
+                AnsibleDescribable.ANSIBLE_CONFIG_FILE_PATH,
+                null,
+                getFrameworkProject(),
+                getFramework(),
+                getNode(),
+                getjobConf()
+        );
+
+        if (null != configFile && configFile.contains("${")) {
+            return DataContextUtils.replaceDataReferences(configFile, getContext().getDataContext());
+        }
+        return configFile;
+    }
+
     
     public AnsibleRunner buildAnsibleRunner() throws ConfigurationException{
 
@@ -786,6 +805,12 @@ public class AnsibleRunnerBuilder {
         String become_password = getBecomePassword();
         if (become_password != null) {
             runner = runner.becomePassword(become_password);
+        }
+
+
+        String configFile = getConfigFile();
+        if (configFile != null) {
+            runner = runner.configFile(configFile);
         }
 
         return runner;

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
@@ -716,6 +716,25 @@ public class AnsibleRunnerBuilder {
         }
         return limit;
     }
+
+    public String getConfigFile() {
+
+        final String configFile;
+        configFile = PropertyResolver.resolveProperty(
+                AnsibleDescribable.ANSIBLE_CONFIG_FILE_PATH,
+                null,
+                getFrameworkProject(),
+                getFramework(),
+                getNode(),
+                getjobConf()
+        );
+
+        if (null != configFile && configFile.contains("${")) {
+            return DataContextUtils.replaceDataReferences(configFile, getContext().getDataContext());
+        }
+        return configFile;
+    }
+
     
     public AnsibleRunner buildAnsibleRunner() throws ConfigurationException{
 
@@ -815,6 +834,12 @@ public class AnsibleRunnerBuilder {
         String become_password = getBecomePassword();
         if (become_password != null) {
             runner = runner.becomePassword(become_password);
+        }
+
+
+        String configFile = getConfigFile();
+        if (configFile != null) {
+            runner = runner.configFile(configFile);
         }
 
         return runner;

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleFileCopier.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleFileCopier.java
@@ -33,6 +33,7 @@ public class AnsibleFileCopier implements FileCopier, AnsibleDescribable {
         builder.name(SERVICE_PROVIDER_NAME);
         builder.title("Ansible File Copier");
         builder.description("Sends a file to a node via the copy module.");
+        builder.property(CONFIG_FILE_PATH);
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(SSH_USER_PROP);
         builder.property(SSH_PASSWORD_STORAGE_PROP);
@@ -43,6 +44,8 @@ public class AnsibleFileCopier implements FileCopier, AnsibleDescribable {
         builder.property(BECOME_AUTH_TYPE_PROP);
         builder.property(BECOME_USER_PROP);
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
+        builder.mapping(ANSIBLE_CONFIG_FILE_PATH,PROJ_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
+        builder.frameworkMapping(ANSIBLE_CONFIG_FILE_PATH,FWK_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
         DESC=builder.build();
   }
 

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleFileCopier.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleFileCopier.java
@@ -33,6 +33,7 @@ public class AnsibleFileCopier implements DestinationFileCopier, AnsibleDescriba
         builder.name(SERVICE_PROVIDER_NAME);
         builder.title("Ansible File Copier");
         builder.description("Sends a file to a node via the copy module.");
+        builder.property(CONFIG_FILE_PATH);
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(SSH_USER_PROP);
         builder.property(SSH_PASSWORD_STORAGE_PROP);
@@ -43,6 +44,8 @@ public class AnsibleFileCopier implements DestinationFileCopier, AnsibleDescriba
         builder.property(BECOME_AUTH_TYPE_PROP);
         builder.property(BECOME_USER_PROP);
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
+        builder.mapping(ANSIBLE_CONFIG_FILE_PATH,PROJ_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
+        builder.frameworkMapping(ANSIBLE_CONFIG_FILE_PATH,FWK_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
         DESC=builder.build();
   }
 

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleNodeExecutor.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleNodeExecutor.java
@@ -33,6 +33,7 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
         builder.description("Runs Ansible Ad-Hoc commands on the nodes using the shell module.");
         builder.property(EXECUTABLE_PROP);
         builder.property(WINDOWS_EXECUTABLE_PROP);
+        builder.property(CONFIG_FILE_PATH);
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(SSH_USER_PROP);
         builder.property(SSH_PASSWORD_STORAGE_PROP);
@@ -47,6 +48,8 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
         builder.frameworkMapping(ANSIBLE_EXECUTABLE,FWK_PROP_PREFIX + ANSIBLE_EXECUTABLE);
         builder.mapping(ANSIBLE_WINDOWS_EXECUTABLE,PROJ_PROP_PREFIX + ANSIBLE_WINDOWS_EXECUTABLE);
         builder.frameworkMapping(ANSIBLE_WINDOWS_EXECUTABLE,FWK_PROP_PREFIX + ANSIBLE_WINDOWS_EXECUTABLE);
+        builder.mapping(ANSIBLE_CONFIG_FILE_PATH,PROJ_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
+        builder.frameworkMapping(ANSIBLE_CONFIG_FILE_PATH,FWK_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
         builder.mapping(ANSIBLE_SSH_AUTH_TYPE,PROJ_PROP_PREFIX + ANSIBLE_SSH_AUTH_TYPE);
         builder.frameworkMapping(ANSIBLE_SSH_AUTH_TYPE,FWK_PROP_PREFIX + ANSIBLE_SSH_AUTH_TYPE);
         builder.mapping(ANSIBLE_SSH_USER,PROJ_PROP_PREFIX + ANSIBLE_SSH_USER);
@@ -132,6 +135,7 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
     } else {
       jobConf.put(AnsibleDescribable.ANSIBLE_DEBUG,"False");
     }
+
 
     AnsibleRunnerBuilder builder = new AnsibleRunnerBuilder(node, context, context.getFramework(), jobConf);
 

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
@@ -59,6 +59,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
   protected String becomeMethod;
   protected String becomeUser;
   protected String becomePassword;
+  protected String configFile;
 
   public AnsibleResourceModelSource(final Framework framework) {
       this.framework = framework;
@@ -119,6 +120,10 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
     becomeMethod = (String) resolveProperty(AnsibleDescribable.ANSIBLE_BECOME_METHOD,null,configuration,executionDataContext);
     becomeUser = (String) resolveProperty(AnsibleDescribable.ANSIBLE_BECOME_USER,null,configuration,executionDataContext);
     becomePassword = (String)  resolveProperty(AnsibleDescribable.ANSIBLE_BECOME_PASSWORD,null,configuration,executionDataContext);
+
+
+    configFile = (String)  resolveProperty(AnsibleDescribable.ANSIBLE_CONFIG_FILE_PATH,null,configuration,executionDataContext);
+
   }
 
   public AnsibleRunner buildAnsibleRunner() throws ResourceModelSourceException{
@@ -182,6 +187,10 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
 	  if (becomePassword != null) {
 		  runner = runner.becomePassword(becomePassword);
 	  }
+
+      if (configFile != null) {
+        runner = runner.configFile(configFile);
+      }
 
 	  return runner;
   }

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSourceFactory.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSourceFactory.java
@@ -31,6 +31,7 @@ public class AnsibleResourceModelSourceFactory implements ResourceModelSourceFac
         builder.description("Imports nodes from Ansible's inventory.");
 
         builder.property(INVENTORY_PROP);
+        builder.property(CONFIG_FILE_PATH);
         builder.property(GATHER_FACTS_PROP);
         builder.property(IGNORE_ERRORS_PROP);
         builder.property(LIMIT_PROP);
@@ -47,6 +48,10 @@ public class AnsibleResourceModelSourceFactory implements ResourceModelSourceFac
         builder.property(BECOME_PASSWORD_PROP);
         builder.mapping(ANSIBLE_INVENTORY,PROJ_PROP_PREFIX + ANSIBLE_INVENTORY);
         builder.frameworkMapping(ANSIBLE_INVENTORY,FWK_PROP_PREFIX + ANSIBLE_INVENTORY);
+        builder.mapping(ANSIBLE_CONFIG_FILE_PATH,PROJ_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
+        builder.frameworkMapping(ANSIBLE_CONFIG_FILE_PATH,FWK_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
+
+
 
         DESC=builder.build();
     }

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSourceFactory.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSourceFactory.java
@@ -31,6 +31,7 @@ public class AnsibleResourceModelSourceFactory implements ResourceModelSourceFac
         builder.description("Imports nodes from Ansible's inventory.");
 
         builder.property(INVENTORY_PROP);
+        builder.property(CONFIG_FILE_PATH);
         builder.property(GATHER_FACTS_PROP);
         builder.property(IGNORE_ERRORS_PROP);
         builder.property(LIMIT_PROP);
@@ -48,6 +49,10 @@ public class AnsibleResourceModelSourceFactory implements ResourceModelSourceFac
         builder.property(BECOME_PASSWORD_PROP);
         builder.mapping(ANSIBLE_INVENTORY,PROJ_PROP_PREFIX + ANSIBLE_INVENTORY);
         builder.frameworkMapping(ANSIBLE_INVENTORY,FWK_PROP_PREFIX + ANSIBLE_INVENTORY);
+        builder.mapping(ANSIBLE_CONFIG_FILE_PATH,PROJ_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
+        builder.frameworkMapping(ANSIBLE_CONFIG_FILE_PATH,FWK_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
+
+
 
         DESC=builder.build();
     }


### PR DESCRIPTION
Support for ANSIBLE_CONFIG per Project on Resource Model, Node Executor and File Copier 

related with: https://github.com/Batix/rundeck-ansible-plugin/issues/100

<img width="1255" alt="screenshot 2017-09-14 17 54 53" src="https://user-images.githubusercontent.com/6034968/30455852-decbe94e-9977-11e7-8b36-a08b39da7403.png">
<img width="1243" alt="screenshot 2017-09-14 17 55 05" src="https://user-images.githubusercontent.com/6034968/30455850-debbf70a-9977-11e7-9bdf-8b82a9e1d43d.png">
<img width="1429" alt="screenshot 2017-09-14 18 09 13" src="https://user-images.githubusercontent.com/6034968/30455849-debb8f0e-9977-11e7-9193-25dceeb80b6d.png">


