### PR TITLE
Adding a handler exception for NullPointerException for ansible_lsb attribute 

### DIFF
--- a/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
@@ -284,7 +284,11 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
           node.setTags(tags);
 
           if (root.has("ansible_lsb")) {
-            node.setDescription(root.getAsJsonObject("ansible_lsb").get("description").getAsString());
+            try {
+              node.setDescription(root.getAsJsonObject("ansible_lsb").get("description").getAsString());
+            }catch(Exception ex){
+              System.out.println("[warn] Problem getting the ansible_lsb.description attribute from node " + hostname);
+            }
           } else {
             StringBuilder sb = new StringBuilder();
 


### PR DESCRIPTION
This PR fixes handle this error:

2017-10-25 13:15:36,743 [NodeService-SourceLoader4] ERROR com.dtolabs.rundeck.core.resources.ExceptionCatchingResourceModelSource – [ResourceModelSource: 1.source (com.batix.rundeck.plugins.AnsibleResourceModelSourceFactory), project: PrivateCloud] 
java.lang.NullPointerException
at com.batix.rundeck.plugins.AnsibleResourceModelSource.getNodes(AnsibleResourceModelSource.java:287)


