### PR TITLE
Add Vault file/password/key-storage reference

### DIFF
--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -104,6 +104,7 @@ public interface AnsibleDescribable extends Describable {
     public static final String ANSIBLE_EXTRA_PARAM = "ansible-extra-param";
     public static final String ANSIBLE_VAULT_PATH = "ansible-vault-path";
     public static final String ANSIBLE_VAULTSTORE_PATH = "ansible-vault-storage-path";
+    public static final String ANSIBLE_VAULT_PASSWORD = "ansible-vault-password";
 
     // ssh configuration
     public static final String ANSIBLE_SSH_PASSWORD = "ansible-ssh-password";
@@ -258,6 +259,15 @@ public interface AnsibleDescribable extends Describable {
     static final Property VAULT_KEY_FILE_PROP = PropertyUtil.string(ANSIBLE_VAULT_PATH, "Vault Key File path",
             "File Path to the ansible vault Key to use",
             false, null);
+
+    static final Property VAULT_PASSWORD_PROP = PropertyBuilder.builder()
+            .string(ANSIBLE_VAULT_PASSWORD)
+            .required(false)
+            .title("Vault Password")
+            .description("Ansible Vault password.")
+            .renderingOption(StringRenderingConstants.DISPLAY_TYPE_KEY,
+                    StringRenderingConstants.DisplayType.PASSWORD)
+            .build();
 
     static final Property VAULT_KEY_STORAGE_PROP = PropertyBuilder.builder()
             .string(ANSIBLE_VAULTSTORE_PATH)

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleFileCopier.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleFileCopier.java
@@ -44,8 +44,14 @@ public class AnsibleFileCopier implements FileCopier, AnsibleDescribable {
         builder.property(BECOME_AUTH_TYPE_PROP);
         builder.property(BECOME_USER_PROP);
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
+        builder.property(VAULT_KEY_FILE_PROP);
+        builder.property(VAULT_KEY_STORAGE_PROP);
         builder.mapping(ANSIBLE_CONFIG_FILE_PATH,PROJ_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
         builder.frameworkMapping(ANSIBLE_CONFIG_FILE_PATH,FWK_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
+        builder.mapping(ANSIBLE_VAULT_PATH,PROJ_PROP_PREFIX + ANSIBLE_VAULT_PATH);
+        builder.frameworkMapping(ANSIBLE_VAULT_PATH,FWK_PROP_PREFIX + ANSIBLE_VAULT_PATH);
+        builder.mapping(ANSIBLE_VAULTSTORE_PATH,PROJ_PROP_PREFIX + ANSIBLE_VAULTSTORE_PATH);
+        builder.frameworkMapping(ANSIBLE_VAULTSTORE_PATH,FWK_PROP_PREFIX + ANSIBLE_VAULTSTORE_PATH);
         DESC=builder.build();
   }
 

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleNodeExecutor.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleNodeExecutor.java
@@ -44,6 +44,8 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
         builder.property(BECOME_AUTH_TYPE_PROP);
         builder.property(BECOME_USER_PROP);
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
+        builder.property(VAULT_KEY_FILE_PROP);
+        builder.property(VAULT_KEY_STORAGE_PROP);
         builder.mapping(ANSIBLE_EXECUTABLE,PROJ_PROP_PREFIX + ANSIBLE_EXECUTABLE);
         builder.frameworkMapping(ANSIBLE_EXECUTABLE,FWK_PROP_PREFIX + ANSIBLE_EXECUTABLE);
         builder.mapping(ANSIBLE_WINDOWS_EXECUTABLE,PROJ_PROP_PREFIX + ANSIBLE_WINDOWS_EXECUTABLE);
@@ -70,8 +72,12 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
         builder.frameworkMapping(ANSIBLE_BECOME_METHOD,FWK_PROP_PREFIX + ANSIBLE_BECOME_METHOD);
         builder.mapping(ANSIBLE_BECOME_PASSWORD_STORAGE_PATH,PROJ_PROP_PREFIX + ANSIBLE_BECOME_PASSWORD_STORAGE_PATH);
         builder.frameworkMapping(ANSIBLE_BECOME_PASSWORD_STORAGE_PATH,FWK_PROP_PREFIX + ANSIBLE_BECOME_PASSWORD_STORAGE_PATH);
+        builder.mapping(ANSIBLE_VAULT_PATH,PROJ_PROP_PREFIX + ANSIBLE_VAULT_PATH);
+        builder.frameworkMapping(ANSIBLE_VAULT_PATH,FWK_PROP_PREFIX + ANSIBLE_VAULT_PATH);
+        builder.mapping(ANSIBLE_VAULTSTORE_PATH,PROJ_PROP_PREFIX + ANSIBLE_VAULTSTORE_PATH);
+        builder.frameworkMapping(ANSIBLE_VAULTSTORE_PATH,FWK_PROP_PREFIX + ANSIBLE_VAULTSTORE_PATH);
 
-        DESC=builder.build();
+      DESC=builder.build();
   }
 
   @Override

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
@@ -61,6 +61,9 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
   protected String becomePassword;
   protected String configFile;
 
+  protected String vaultFile;
+  protected String vaultPassword;
+
   public AnsibleResourceModelSource(final Framework framework) {
       this.framework = framework;
   }
@@ -123,6 +126,9 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
 
 
     configFile = (String)  resolveProperty(AnsibleDescribable.ANSIBLE_CONFIG_FILE_PATH,null,configuration,executionDataContext);
+    vaultFile = (String) resolveProperty(AnsibleDescribable.ANSIBLE_VAULT_PATH,null,configuration,executionDataContext);
+    vaultPassword = (String) resolveProperty(AnsibleDescribable.ANSIBLE_VAULT_PASSWORD,null,configuration,executionDataContext);
+
 
   }
 
@@ -190,6 +196,20 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
 
       if (configFile != null) {
         runner = runner.configFile(configFile);
+      }
+
+      if(vaultPassword!=null) {
+        runner.vaultPass(vaultPassword);
+      }
+
+      if (vaultFile != null) {
+        String vaultPassword;
+        try {
+          vaultPassword = new String(Files.readAllBytes(Paths.get(vaultFile)));
+        } catch (IOException e) {
+          throw new ResourceModelSourceException("Could not read vault file " + vaultFile,e);
+        }
+        runner.vaultPass(vaultPassword);
       }
 
 	  return runner;

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSourceFactory.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSourceFactory.java
@@ -43,6 +43,8 @@ public class AnsibleResourceModelSourceFactory implements ResourceModelSourceFac
         builder.property(SSH_PASSWORD_PROP);
         builder.property(SSH_KEY_FILE_PROP); 
         builder.property(SSH_TIMEOUT_PROP);
+        builder.property(VAULT_KEY_FILE_PROP);
+        builder.property(VAULT_PASSWORD_PROP);
         builder.property(BECOME_PROP);
         builder.property(BECOME_AUTH_TYPE_PROP);
         builder.property(BECOME_USER_PROP);
@@ -51,7 +53,10 @@ public class AnsibleResourceModelSourceFactory implements ResourceModelSourceFac
         builder.frameworkMapping(ANSIBLE_INVENTORY,FWK_PROP_PREFIX + ANSIBLE_INVENTORY);
         builder.mapping(ANSIBLE_CONFIG_FILE_PATH,PROJ_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
         builder.frameworkMapping(ANSIBLE_CONFIG_FILE_PATH,FWK_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
-
+        builder.mapping(ANSIBLE_VAULT_PASSWORD,PROJ_PROP_PREFIX + ANSIBLE_VAULT_PASSWORD);
+        builder.frameworkMapping(ANSIBLE_VAULT_PASSWORD,FWK_PROP_PREFIX + ANSIBLE_VAULT_PASSWORD);
+        builder.mapping(ANSIBLE_VAULT_PATH,PROJ_PROP_PREFIX + ANSIBLE_VAULT_PATH);
+        builder.frameworkMapping(ANSIBLE_VAULT_PATH,FWK_PROP_PREFIX + ANSIBLE_VAULT_PATH);
 
 
         DESC=builder.build();


### PR DESCRIPTION
 This PR Add Vault file/password/key-storage reference to Resource Model/NodeExecutor/File Copier, so you can use encrypting ansible-vault files.
