### PR TITLE
Add working directory / base directory option

### DIFF
--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -408,7 +408,7 @@ public interface AnsibleDescribable extends Describable {
             .description("Set ansible config file path.")
             .build();
 
-    static final Property BASE_DIR_PATH = PropertyBuilder.builder()
+    static final Property BASE_DIR_PROP = PropertyBuilder.builder()
             .string(ANSIBLE_BASE_DIR_PATH)
             .required(false)
             .title("Ansible base directory path")

--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -16,11 +16,11 @@ public interface AnsibleDescribable extends Describable {
         sh("/bin/sh");
 
     	private final String executable;
-    	
+
     	Executable(String executable) {
     		this.executable = executable;
     	}
-    	
+
     	public String getValue() {
 			return executable;
 		}
@@ -60,7 +60,7 @@ public interface AnsibleDescribable extends Describable {
     public static enum AuthenticationType {
         privateKey,
         password;
-    	
+
     	public static String[] getValues() {
     	    java.util.LinkedList<String> list = new LinkedList<String>();
     	    for (AuthenticationType s : AuthenticationType.values()) {
@@ -73,7 +73,7 @@ public interface AnsibleDescribable extends Describable {
     public static enum BecomeMethodType {
         sudo,
         su;
-    	
+
     	public static String[] getValues() {
     	    java.util.LinkedList<String> list = new LinkedList<String>();
     	    for (BecomeMethodType s : BecomeMethodType.values()) {
@@ -82,7 +82,7 @@ public interface AnsibleDescribable extends Describable {
     	    return list.toArray(new String[list.size()]);
     	}
     }
-    
+
     public static final String SERVICE_PROVIDER_TYPE = "ansible-service";
     public static final String ANSIBLE_PLAYBOOK_PATH = "ansible-playbook";
     public static final String ANSIBLE_PLAYBOOK_INLINE = "ansible-playbook-inline";
@@ -129,6 +129,7 @@ public interface AnsibleDescribable extends Describable {
 
 
     public static final String ANSIBLE_CONFIG_FILE_PATH = "ansible-config-file-path";
+    public static final String ANSIBLE_BASE_DIR_PATH = "ansible-base-dir-path";
 
     public static final String PROJ_PROP_PREFIX = "project.";
     public static final String FWK_PROP_PREFIX = "framework.";
@@ -140,7 +141,7 @@ public interface AnsibleDescribable extends Describable {
               true,
               null
     );
-    
+
     public static Property PLAYBOOK_INLINE_PROP = PropertyBuilder.builder()
     		.string(ANSIBLE_PLAYBOOK_INLINE)
     		.required(false)
@@ -151,7 +152,7 @@ public interface AnsibleDescribable extends Describable {
         .renderingOption(StringRenderingConstants.CODE_SYNTAX_SELECTABLE, false)
     		.build();
 
- 
+
     public static Property MODULE_PROP = PropertyUtil.string(
               ANSIBLE_MODULE,
               "Module",
@@ -212,7 +213,7 @@ public interface AnsibleDescribable extends Describable {
               false,
               ""
     );
-        
+
     public static Property DISABLE_LIMIT_PROP = PropertyUtil.bool(
     		 ANSIBLE_DISABLE_LIMIT,
     		 "Disable Limit",
@@ -236,7 +237,7 @@ public interface AnsibleDescribable extends Describable {
             false,
             ""
     );
-    
+
     static final Property EXTRA_VARS_PROP = PropertyBuilder.builder()
             .string(ANSIBLE_EXTRA_VARS)
             .required(false)
@@ -246,7 +247,7 @@ public interface AnsibleDescribable extends Describable {
             .renderingOption(StringRenderingConstants.CODE_SYNTAX_MODE, "yaml")
             .renderingOption(StringRenderingConstants.CODE_SYNTAX_SELECTABLE, true)
             .build();
-    
+
     public static Property EXTRA_ATTRS_PROP = PropertyUtil.string(
             ANSIBLE_EXTRA_PARAM,
             "Extra Ansible arguments",
@@ -254,7 +255,7 @@ public interface AnsibleDescribable extends Describable {
             false,
             ""
       );
-    
+
     static final Property VAULT_KEY_FILE_PROP = PropertyUtil.string(ANSIBLE_VAULT_PATH, "Vault Key File path",
             "File Path to the ansible vault Key to use",
             false, null);
@@ -280,7 +281,7 @@ public interface AnsibleDescribable extends Describable {
             .renderingOption(StringRenderingConstants.GROUP_NAME,"SSH Connection")
             .build();
 
-    
+
     static final Property SSH_KEY_STORAGE_PROP = PropertyBuilder.builder()
             .string(ANSIBLE_SSH_KEYPATH_STORAGE_PATH)
             .required(false)
@@ -405,6 +406,13 @@ public interface AnsibleDescribable extends Describable {
             .required(false)
             .title("Ansible config file path")
             .description("Set ansible config file path.")
+            .build();
+
+    static final Property BASE_DIR_PATH = PropertyBuilder.builder()
+            .string(ANSIBLE_BASE_DIR_PATH)
+            .required(false)
+            .title("Ansible base directory path")
+            .description("Set ansible base directory path.")
             .build();
 
 }

--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -142,6 +142,14 @@ public interface AnsibleDescribable extends Describable {
               null
     );
 
+    public static Property BASE_DIR_PROP = PropertyUtil.string(
+    			ANSIBLE_BASE_DIR_PATH,
+              "Ansible base directory path",
+              "Set ansible base directory path.",
+              false,
+              null
+    );
+
     public static Property PLAYBOOK_INLINE_PROP = PropertyBuilder.builder()
     		.string(ANSIBLE_PLAYBOOK_INLINE)
     		.required(false)
@@ -407,12 +415,4 @@ public interface AnsibleDescribable extends Describable {
             .title("Ansible config file path")
             .description("Set ansible config file path.")
             .build();
-
-    static final Property BASE_DIR_PROP = PropertyBuilder.builder()
-            .string(ANSIBLE_BASE_DIR_PATH)
-            .required(false)
-            .title("Ansible base directory path")
-            .description("Set ansible base directory path.")
-            .build();
-
 }

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
@@ -94,7 +94,8 @@ public class AnsibleRunner {
 
   private boolean debug = false;
 
-  private Path tempDirectory;
+  private Path baseDirectory;
+  private boolean usingTempDirectory;
   private boolean retainTempDirectory;
   private final List<String> limits = new ArrayList<>();
   private int result;
@@ -281,12 +282,23 @@ public class AnsibleRunner {
   }
 
   /**
-   * Specify in which directory Ansible is run.
-   * If none is specified, a temporary directory will be created automatically.
+   * Specify in which directory Ansible is run, noting it is a temporary directory.
    */
   public AnsibleRunner tempDirectory(Path dir) {
     if (dir != null) {
-      this.tempDirectory = dir;
+      this.baseDirectory = dir;
+      this.usingTempDirectory = true;
+    }
+    return this;
+  }
+
+  /**
+   * Specify in which directory Ansible is run.
+   * A temporary directory will be used if none is specified.
+   */
+  public AnsibleRunner baseDirectory(Path dir) {
+    if (dir != null) {
+      this.baseDirectory = dir;
     }
     return this;
   }
@@ -313,10 +325,12 @@ public class AnsibleRunner {
     }
     done = true;
 
-    if (tempDirectory == null) {
-      tempDirectory = Files.createTempDirectory("ansible-rundeck");
+    if (baseDirectory == null) {
+      // Use a temporary directory and mark it for possible removal later
+      this.usingTempDirectory = true;
+      baseDirectory = Files.createTempDirectory("ansible-rundeck");
     }
-    
+
     File tempPlaybook = null;
     File tempFile = null;
     File tempVaultFile = null;
@@ -338,11 +352,11 @@ public class AnsibleRunner {
         procArgs.add(arg);
       }
       procArgs.add("-t");
-      procArgs.add(tempDirectory.toFile().getAbsolutePath());
+      procArgs.add(baseDirectory.toFile().getAbsolutePath());
     } else if (type == AnsibleCommand.PlaybookPath) {
       procArgs.add(playbook);
     } else if (type == AnsibleCommand.PlaybookInline) {
-    	
+
 	  tempPlaybook = File.createTempFile("ansible-runner", "playbook");
 	  Files.write(tempPlaybook.toPath(), playbook.toString().getBytes());
 	  procArgs.add(tempPlaybook.getAbsolutePath());
@@ -355,7 +369,7 @@ public class AnsibleRunner {
     if (limits != null && limits.size() == 1) {
       procArgs.add("-l");
       procArgs.add(limits.get(0));
-      
+
     } else if (limits != null && limits.size() > 1) {
       tempFile = File.createTempFile("ansible-runner", "targets");
       StringBuilder sb = new StringBuilder();
@@ -439,7 +453,7 @@ public class AnsibleRunner {
     // execute the ansible process
     ProcessBuilder processBuilder = new ProcessBuilder()
       .command(procArgs)
-      .directory(tempDirectory.toFile()); // set cwd
+      .directory(baseDirectory.toFile()); // set cwd
     Process proc = null;
 
     Map<String, String> processEnvironment = processBuilder.environment();
@@ -460,7 +474,7 @@ public class AnsibleRunner {
       proc = processBuilder.start();
       OutputStream stdin = proc.getOutputStream();
       OutputStreamWriter stdinw = new OutputStreamWriter(stdin);
-      
+
       if (sshUsePassword) {
          if (sshPass != null && sshPass.length() > 0) {
         	 stdinw.write(sshPass+"\n");
@@ -527,8 +541,8 @@ public class AnsibleRunner {
         if (tempVaultFile != null && !tempVaultFile.delete()) {
           tempVaultFile.deleteOnExit();
         }
-        if (tempDirectory != null && !retainTempDirectory) {
-          deleteTempDirectory(tempDirectory);
+        if (usingTempDirectory && !retainTempDirectory) {
+          deleteTempDirectory(baseDirectory);
         }
     }
 

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
@@ -10,6 +10,7 @@ import java.nio.file.FileVisitResult;
 import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.SimpleFileVisitor;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.ArrayList;

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunner.java
@@ -296,9 +296,9 @@ public class AnsibleRunner {
    * Specify in which directory Ansible is run.
    * A temporary directory will be used if none is specified.
    */
-  public AnsibleRunner baseDirectory(Path dir) {
+  public AnsibleRunner baseDirectory(String dir) {
     if (dir != null) {
-      this.baseDirectory = dir;
+      this.baseDirectory = Paths.get(dir);
     }
     return this;
   }

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
@@ -183,7 +183,7 @@ public class AnsibleRunnerBuilder {
     }
 
     public String getSshPassword()  throws ConfigurationException{
-        
+
         //look for option values first
         //typically jobs use secure options to dynamically setup the ssh password
         final String passwordOption = PropertyResolver.resolveProperty(
@@ -195,7 +195,7 @@ public class AnsibleRunnerBuilder {
                     getjobConf()
                     );
         String sshPassword = PropertyResolver.evaluateSecureOption(passwordOption, getContext());
-        
+
         if(null!=sshPassword){
             // is true if there is an ssh option defined in the private data context
             return sshPassword;
@@ -244,7 +244,7 @@ public class AnsibleRunnerBuilder {
         final String stimeout = PropertyResolver.resolveProperty(
         		    AnsibleDescribable.ANSIBLE_SSH_TIMEOUT,
                     null,
-                    getFrameworkProject(), 
+                    getFrameworkProject(),
                     getFramework(),
                     getNode(),
                     getjobConf()
@@ -303,7 +303,7 @@ public class AnsibleRunnerBuilder {
                    getFramework(),getNode(),
                    getjobConf()
                    );
-        
+
         if (null != user && user.contains("${")) {
             return DataContextUtils.replaceDataReferences(user, getContext().getDataContext());
         }
@@ -337,13 +337,13 @@ public class AnsibleRunnerBuilder {
     	            getNode(),
     	            getjobConf()
     	            );
-    	
+
     	if (null != extraParams && extraParams.contains("${")) {
     	     return DataContextUtils.replaceDataReferences(extraParams, getContext().getDataContext());
     	}
     	return extraParams;
     }
-    
+
     public BecomeMethodType getBecomeMethod() {
         String becomeMethod = PropertyResolver.resolveProperty(
                    AnsibleDescribable.ANSIBLE_BECOME_METHOD,
@@ -366,7 +366,7 @@ public class AnsibleRunnerBuilder {
     }
 
 
-    public String getBecomePasswordStoragePath() { 
+    public String getBecomePasswordStoragePath() {
         String path = PropertyResolver.resolveProperty(
         		AnsibleDescribable.ANSIBLE_BECOME_PASSWORD_STORAGE_PATH,
                 null,
@@ -391,7 +391,7 @@ public class AnsibleRunnerBuilder {
         final String passwordOption = PropertyResolver.resolveProperty(
                     AnsibleDescribable.ANSIBLE_BECOME_PASSWORD_OPTION,
                     AnsibleDescribable.DEFAULT_ANSIBLE_BECOME_PASSWORD_OPTION,
-                    getFrameworkProject(), 
+                    getFrameworkProject(),
                     getFramework(),
                     getNode(),
                     getjobConf()
@@ -401,7 +401,7 @@ public class AnsibleRunnerBuilder {
     }
 
     public String getBecomePassword()  throws ConfigurationException{
-        
+
         //look for option values first
         //typically jobs use secure options to dynamically setup the become password
         String passwordOption = PropertyResolver.resolveProperty(
@@ -413,7 +413,7 @@ public class AnsibleRunnerBuilder {
                     getjobConf()
                     );
         String becomePassword = PropertyResolver.evaluateSecureOption(passwordOption, getContext());
-        
+
         if(null!=becomePassword){
             // is true if there is a become option defined in the private data context
             return becomePassword;
@@ -530,7 +530,7 @@ public class AnsibleRunnerBuilder {
         }
         return playbook;
     }
-    
+
     public String getPlaybookInline() {
     	 	String playbook = null;
          if ( getjobConf().containsKey(AnsibleDescribable.ANSIBLE_PLAYBOOK_INLINE) ) {
@@ -548,7 +548,7 @@ public class AnsibleRunnerBuilder {
         if ( getjobConf().containsKey(AnsibleDescribable.ANSIBLE_MODULE) ) {
         	module = (String) jobConf.get(AnsibleDescribable.ANSIBLE_MODULE);
         }
-        
+
         if (null != module && module.contains("${")) {
             return DataContextUtils.replaceDataReferences(module, getContext().getDataContext());
         }
@@ -688,7 +688,7 @@ public class AnsibleRunnerBuilder {
 
     public String getLimit() {
         final String limit;
-        
+
         // Return Null if Disabled
         if("true".equals(PropertyResolver.resolveProperty(
         				AnsibleDescribable.ANSIBLE_DISABLE_LIMIT,
@@ -697,10 +697,10 @@ public class AnsibleRunnerBuilder {
                         getFramework(),
                         getNode(),
                         getjobConf()))){
-        	
+
         	return null;
         }
-                 
+
         // Get Limit from Rundeck
         limit = PropertyResolver.resolveProperty(
                      AnsibleDescribable.ANSIBLE_LIMIT,
@@ -735,14 +735,32 @@ public class AnsibleRunnerBuilder {
         return configFile;
     }
 
-    
+    public String getBaseDir() {
+
+        final String baseDir;
+        configFile = PropertyResolver.resolveProperty(
+                AnsibleDescribable.ANSIBLE_BASE_DIR_PATH,
+                null,
+                getFrameworkProject(),
+                getFramework(),
+                getNode(),
+                getjobConf()
+        );
+
+        if (null != baseDir && baseDir.contains("${")) {
+            return DataContextUtils.replaceDataReferences(baseDir, getContext().getDataContext());
+        }
+        return baseDir;
+    }
+
+
     public AnsibleRunner buildAnsibleRunner() throws ConfigurationException{
 
         AnsibleRunner runner = null;
-        
+
         String playbook;
         String module;
-        
+
         if ((playbook = getPlaybookPath()) != null) {
             runner = AnsibleRunner.playbookPath(playbook);
         } else if ((playbook = getPlaybookInline()) != null) {
@@ -750,7 +768,7 @@ public class AnsibleRunnerBuilder {
         } else if ((module  = getModule()) != null) {
             runner = AnsibleRunner.adHoc(module, getModuleArgs());
         } else {
-            throw new ConfigurationException("Missing module or playbook job arguments");          
+            throw new ConfigurationException("Missing module or playbook job arguments");
         }
 
         final AuthenticationType authType = getSshAuthenticationType();
@@ -765,7 +783,7 @@ public class AnsibleRunnerBuilder {
                 runner = runner.sshUsePassword(Boolean.TRUE).sshPass(password);
             }
         }
-        
+
         // set rundeck options as environment variables
         Map<String,String> options = context.getDataContext().get("option");
         if (options != null) {
@@ -781,7 +799,7 @@ public class AnsibleRunnerBuilder {
         if (limit != null) {
             runner = runner.limit(limit);
         }
-        
+
         Boolean debug = getDebug();
         if (debug != null) {
             if (debug == Boolean.TRUE) {
@@ -800,7 +818,7 @@ public class AnsibleRunnerBuilder {
         if (extraVars != null) {
             runner = runner.extraVars(extraVars);
         }
-        
+
         String user = getSshUser();
         if (user != null) {
             runner = runner.sshUser(user);
@@ -840,6 +858,11 @@ public class AnsibleRunnerBuilder {
         String configFile = getConfigFile();
         if (configFile != null) {
             runner = runner.configFile(configFile);
+        }
+
+        String baseDir = getBaseDir();
+        if (baseDir != null) {
+            runner = runner.baseDirectory(baseDir);
         }
 
         return runner;

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
@@ -736,23 +736,16 @@ public class AnsibleRunnerBuilder {
     }
 
     public String getBaseDir() {
-
-        final String baseDir;
-        baseDir = PropertyResolver.resolveProperty(
-                AnsibleDescribable.ANSIBLE_BASE_DIR_PATH,
-                null,
-                getFrameworkProject(),
-                getFramework(),
-                getNode(),
-                getjobConf()
-        );
+        String baseDir = null;
+        if ( getjobConf().containsKey(AnsibleDescribable.ANSIBLE_BASE_DIR_PATH) ) {
+        	baseDir = (String) jobConf.get(AnsibleDescribable.ANSIBLE_BASE_DIR_PATH);
+        }
 
         if (null != baseDir && baseDir.contains("${")) {
             return DataContextUtils.replaceDataReferences(baseDir, getContext().getDataContext());
         }
         return baseDir;
     }
-
 
     public AnsibleRunner buildAnsibleRunner() throws ConfigurationException{
 

--- a/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
@@ -738,7 +738,7 @@ public class AnsibleRunnerBuilder {
     public String getBaseDir() {
 
         final String baseDir;
-        configFile = PropertyResolver.resolveProperty(
+        baseDir = PropertyResolver.resolveProperty(
                 AnsibleDescribable.ANSIBLE_BASE_DIR_PATH,
                 null,
                 getFrameworkProject(),

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleModuleWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleModuleWorkflowStep.java
@@ -19,7 +19,7 @@ import java.util.Map;
 public class AnsibleModuleWorkflowStep implements StepPlugin, AnsibleDescribable {
 
     public static final String SERVICE_PROVIDER_NAME = "com.batix.rundeck.plugins.AnsibleModuleWorkflowStep";
-	
+
     public static Description DESC = null;
 
     static {
@@ -28,13 +28,14 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, AnsibleDescribable
         builder.title("Ansible Module");
         builder.description("Runs an Ansible Module on selected nodes.");
 
+        builder.property(BASE_DIR_PROP);
         builder.property(MODULE_PROP);
         builder.property(MODULE_ARGS_PROP);
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(SSH_USER_PROP);
         builder.property(SSH_PASSWORD_STORAGE_PROP);
-        builder.property(SSH_KEY_FILE_PROP); 
-        builder.property(SSH_KEY_STORAGE_PROP); 
+        builder.property(SSH_KEY_FILE_PROP);
+        builder.property(SSH_KEY_STORAGE_PROP);
         builder.property(SSH_TIMEOUT_PROP);
         builder.property(BECOME_PROP);
         builder.property(BECOME_AUTH_TYPE_PROP);
@@ -59,7 +60,7 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, AnsibleDescribable
     if (limit != "") {
         configuration.put(AnsibleDescribable.ANSIBLE_LIMIT,limit);
     }
-    
+
     // set log level
     if (context.getDataContext().get("job").get("loglevel").equals("DEBUG")) {
         configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"True");
@@ -70,7 +71,7 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, AnsibleDescribable
     AnsibleRunnerBuilder builder = new AnsibleRunnerBuilder(context.getExecutionContext(),context.getFramework(),configuration);
 
     try {
-        runner = builder.buildAnsibleRunner();  
+        runner = builder.buildAnsibleRunner();
     } catch (ConfigurationException e) {
           throw new StepException("Error configuring Ansible runner: "+e.getMessage(), e, AnsibleException.AnsibleFailureReason.ParseArgumentsError);
     }

--- a/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookInlineWorkflowStep.java
@@ -17,17 +17,18 @@ import java.util.Map;
 
 @Plugin(name = AnsiblePlaybookInlineWorkflowStep.SERVICE_PROVIDER_NAME, service = ServiceNameConstants.WorkflowStep)
 public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDescribable {
-	
+
 	public static final String SERVICE_PROVIDER_NAME = "com.batix.rundeck.plugins.AnsiblePlaybookInlineWorkflowStep";
-	
+
 	public static Description DESC = null;
-	
+
     static {
         DescriptionBuilder builder = DescriptionBuilder.builder();
         builder.name(SERVICE_PROVIDER_NAME);
         builder.title("Ansible Playbook Inline");
         builder.description("Runs an Inline Ansible Playbook.");
 
+				builder.property(BASE_DIR_PROP);
         builder.property(PLAYBOOK_INLINE_PROP);
         builder.property(EXTRA_VARS_PROP);
         builder.property(VAULT_KEY_FILE_PROP);
@@ -36,8 +37,8 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(SSH_USER_PROP);
         builder.property(SSH_PASSWORD_STORAGE_PROP);
-        builder.property(SSH_KEY_FILE_PROP); 
-        builder.property(SSH_KEY_STORAGE_PROP); 
+        builder.property(SSH_KEY_FILE_PROP);
+        builder.property(SSH_KEY_STORAGE_PROP);
         builder.property(SSH_TIMEOUT_PROP);
         builder.property(BECOME_PROP);
         builder.property(BECOME_AUTH_TYPE_PROP);

--- a/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookWorkflowStep.java
@@ -17,17 +17,18 @@ import java.util.Map;
 
 @Plugin(name = AnsiblePlaybookWorkflowStep.SERVICE_PROVIDER_NAME, service = ServiceNameConstants.WorkflowStep)
 public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribable {
-	
+
 	public static final String SERVICE_PROVIDER_NAME = "com.batix.rundeck.plugins.AnsiblePlaybookWorkflowStep";
-	
+
 	public static Description DESC = null;
-	
+
     static {
         DescriptionBuilder builder = DescriptionBuilder.builder();
         builder.name(SERVICE_PROVIDER_NAME);
         builder.title("Ansible Playbook");
         builder.description("Runs an Ansible Playbook.");
 
+				builder.property(BASE_DIR_PROP);
         builder.property(PLAYBOOK_PATH_PROP);
         builder.property(EXTRA_VARS_PROP);
         builder.property(VAULT_KEY_FILE_PROP);
@@ -36,8 +37,8 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(SSH_USER_PROP);
         builder.property(SSH_PASSWORD_STORAGE_PROP);
-        builder.property(SSH_KEY_FILE_PROP); 
-        builder.property(SSH_KEY_STORAGE_PROP); 
+        builder.property(SSH_KEY_FILE_PROP);
+        builder.property(SSH_KEY_STORAGE_PROP);
         builder.property(SSH_TIMEOUT_PROP);
         builder.property(BECOME_PROP);
         builder.property(BECOME_AUTH_TYPE_PROP);


### PR DESCRIPTION
This PR is unfortunately **untested** since I don't know how to build the code. I'm mainly after feedback at this point. It should be a fix for #47 even though the issue was closed.

The primary purpose is to allow a base directory per workflow step to be set that the Ansible repository is stored in. A job could use multiple repositories, or use a repository that is not in /etc/ansible. The repository path needs to be set when using custom Ansible modules and plugins that are stored with the repository. I believe referencing roles will also be an issue.