### PR TITLE
Added serial:10 to gather-hosts.yml playbook

### DIFF
--- a/src/main/resources/gather-hosts.yml
+++ b/src/main/resources/gather-hosts.yml
@@ -3,6 +3,7 @@
   vars:
     facts: True
   gather_facts: "{{facts}}"
+  serial: 10
   tasks:
     - local_action: file path="{{tmpdir}}/data" state=directory
       run_once: yes


### PR DESCRIPTION
When you have lots of hosts in the inventory, gathering big inventories at once kills the CPU. Setting a lower serial gets better results.