### PR TITLE
Ansible inventory generation from Rundeck nodes

### DIFF
--- a/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleDescribable.java
@@ -87,6 +87,7 @@ public interface AnsibleDescribable extends Describable {
     public static final String ANSIBLE_PLAYBOOK_PATH = "ansible-playbook";
     public static final String ANSIBLE_PLAYBOOK_INLINE = "ansible-playbook-inline";
     public static final String ANSIBLE_INVENTORY = "ansible-inventory";
+    public static final String ANSIBLE_GENERATE_INVENTORY = "ansible-generate-inventory";
     public static final String ANSIBLE_MODULE = "ansible-module";
     public static final String ANSIBLE_MODULE_ARGS = "ansible-module-args";
     public static final String ANSIBLE_DEBUG = "ansible-debug";
@@ -170,6 +171,13 @@ public interface AnsibleDescribable extends Describable {
 
     public static Property INVENTORY_PROP = PropertyUtil.string(ANSIBLE_INVENTORY, "ansible inventory File path",
             "File Path to the ansible inventory to use, It can be blank if \"Ansible config file path\" is set  ", false, null);
+
+    static final Property GENERATE_INVENTORY_PROP = PropertyBuilder.builder()
+    .booleanType(ANSIBLE_GENERATE_INVENTORY)
+    .required(false)
+    .title("Generate inventory")
+    .description("Generate Ansible inventory from Rundeck nodes.")
+    .build();
 
     public static Property EXECUTABLE_PROP = PropertyUtil.freeSelect(
               ANSIBLE_EXECUTABLE,

--- a/src/main/java/com/batix/rundeck/core/AnsibleInventory.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleInventory.java
@@ -1,0 +1,50 @@
+package com.batix.rundeck.core;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AnsibleInventory {
+  
+  public class AnsibleInventoryHosts {
+    
+    protected Map<String, Map<String, String>> hosts = new HashMap<String, Map<String, String>>();
+    protected Map<String, AnsibleInventoryHosts> children = new HashMap<String, AnsibleInventoryHosts>();
+  
+    public AnsibleInventoryHosts addHost(String nodeName) {
+      hosts.put(nodeName, new HashMap<String, String>());
+      return this;
+    }
+
+    public AnsibleInventoryHosts addHost(String nodeName, String host, Map<String, String> attributes) {
+      attributes.put("ansible_host", host);
+      hosts.put(nodeName, attributes);
+      return this;
+    }
+
+    public AnsibleInventoryHosts getOrAddChildHostGroup(String groupName) {
+      children.putIfAbsent(groupName, new AnsibleInventoryHosts());
+      return children.get(groupName);
+    }
+  }
+
+  protected AnsibleInventoryHosts all = new AnsibleInventoryHosts();
+
+  public AnsibleInventory addHost(String nodeName, String host, Map<String, String> attributes) {
+    // Remove attributes that are reserved in Ansible
+    String[] reserved = { "hostvars", "group_names", "groups", "environment" };
+    for (String r: reserved){
+      attributes.remove(r);
+    }
+    all.addHost(nodeName, host, attributes);
+    // Create Ansible groups by attribute
+    // Group by osFamily is needed for windows hosts setup
+    String[] attributeGroups = { "osFamily" };
+    for (String g: attributeGroups) {
+      if (attributes.containsKey(g)) {
+        String groupName = attributes.get(g).toLowerCase();
+        all.getOrAddChildHostGroup(groupName).addHost(nodeName);
+      }
+    }
+    return this;
+  }
+}

--- a/src/main/java/com/batix/rundeck/core/AnsibleInventoryBuilder.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleInventoryBuilder.java
@@ -1,0 +1,37 @@
+package com.batix.rundeck.core;
+
+import com.dtolabs.rundeck.core.common.INodeEntry;
+import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.util.Collection;
+import java.util.HashMap;
+
+import com.google.gson.Gson;
+
+public class AnsibleInventoryBuilder {
+
+    private final Collection<INodeEntry> nodes;
+
+    public AnsibleInventoryBuilder(Collection<INodeEntry> nodes) {
+        this.nodes = nodes;
+    }
+
+    public File buildInventory() throws ConfigurationException {
+        try {
+            File file = File.createTempFile("ansible-inventory", ".json");
+            file.deleteOnExit();
+            PrintWriter writer = new PrintWriter(file);
+            AnsibleInventory ai = new AnsibleInventory();
+            for (INodeEntry e : nodes) {
+                ai.addHost(e.getNodename(), e.getHostname(), new HashMap<String, String>(e.getAttributes()));
+            }
+            writer.write(new Gson().toJson(ai));
+            writer.close();
+            return file;
+        } catch (Exception e) {
+            throw new ConfigurationException("Could not write temporary inventory: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleFileCopier.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleFileCopier.java
@@ -131,6 +131,8 @@ public class AnsibleFileCopier implements FileCopier, AnsibleDescribable {
           throw new FileCopierException("Error running Ansible.", AnsibleFailureReason.AnsibleError, e);
     }
 
+    builder.cleanupTempFiles();
+
     return destinationPath;
   }
 

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleModuleWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleModuleWorkflowStep.java
@@ -67,7 +67,7 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, AnsibleDescribable
         configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"False");
     }
 
-    AnsibleRunnerBuilder builder = new AnsibleRunnerBuilder(context.getExecutionContext(),context.getFramework(),configuration);
+    AnsibleRunnerBuilder builder = new AnsibleRunnerBuilder(context.getExecutionContext(),context.getFramework(),context.getNodes(),configuration);
 
     try {
         runner = builder.buildAnsibleRunner();  
@@ -83,6 +83,8 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, AnsibleDescribable
     } catch (Exception e) {
         throw new StepException(e.getMessage(),e,AnsibleException.AnsibleFailureReason.AnsibleError);
     }
+
+    builder.cleanupTempFiles();
   }
 
   @Override

--- a/src/main/java/com/batix/rundeck/plugins/AnsibleNodeExecutor.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleNodeExecutor.java
@@ -34,6 +34,7 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
         builder.property(EXECUTABLE_PROP);
         builder.property(WINDOWS_EXECUTABLE_PROP);
         builder.property(CONFIG_FILE_PATH);
+        builder.property(GENERATE_INVENTORY_PROP);
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(SSH_USER_PROP);
         builder.property(SSH_PASSWORD_STORAGE_PROP);
@@ -50,6 +51,8 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
         builder.frameworkMapping(ANSIBLE_WINDOWS_EXECUTABLE,FWK_PROP_PREFIX + ANSIBLE_WINDOWS_EXECUTABLE);
         builder.mapping(ANSIBLE_CONFIG_FILE_PATH,PROJ_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
         builder.frameworkMapping(ANSIBLE_CONFIG_FILE_PATH,FWK_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
+        builder.mapping(ANSIBLE_GENERATE_INVENTORY,PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
+        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY,FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
         builder.mapping(ANSIBLE_SSH_AUTH_TYPE,PROJ_PROP_PREFIX + ANSIBLE_SSH_AUTH_TYPE);
         builder.frameworkMapping(ANSIBLE_SSH_AUTH_TYPE,FWK_PROP_PREFIX + ANSIBLE_SSH_AUTH_TYPE);
         builder.mapping(ANSIBLE_SSH_USER,PROJ_PROP_PREFIX + ANSIBLE_SSH_USER);
@@ -150,6 +153,8 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable {
     } catch (Exception e) {
         return NodeExecutorResultImpl.createFailure(AnsibleException.AnsibleFailureReason.AnsibleError, e.getMessage(), node);
     }
+
+    builder.cleanupTempFiles();
 
     return NodeExecutorResultImpl.createSuccess(node);
   }

--- a/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookInlineWorkflowStep.java
@@ -69,7 +69,7 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"False");
     }
 
-    AnsibleRunnerBuilder builder = new AnsibleRunnerBuilder(context.getExecutionContext(),context.getFramework(),configuration);
+    AnsibleRunnerBuilder builder = new AnsibleRunnerBuilder(context.getExecutionContext(),context.getFramework(),context.getNodes(),configuration);
 
     try {
         runner = builder.buildAnsibleRunner();
@@ -84,8 +84,9 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         throw new StepException(e.getMessage(), e, e.getFailureReason());
     } catch (Exception e) {
         throw new StepException(e.getMessage(),e,AnsibleException.AnsibleFailureReason.AnsibleError);
-
     }
+
+    builder.cleanupTempFiles();
   }
 
   @Override

--- a/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsiblePlaybookWorkflowStep.java
@@ -69,7 +69,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"False");
     }
 
-    AnsibleRunnerBuilder builder = new AnsibleRunnerBuilder(context.getExecutionContext(),context.getFramework(),configuration);
+    AnsibleRunnerBuilder builder = new AnsibleRunnerBuilder(context.getExecutionContext(),context.getFramework(),context.getNodes(),configuration);
 
     try {
         runner = builder.buildAnsibleRunner();
@@ -84,8 +84,9 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         throw new StepException(e.getMessage(), e, e.getFailureReason());
     } catch (Exception e) {
         throw new StepException(e.getMessage(),e,AnsibleException.AnsibleFailureReason.AnsibleError);
-
     }
+
+    builder.cleanupTempFiles();
   }
 
   @Override


### PR DESCRIPTION
In our use case we generate Ansible inventory from Rundeck nodes. So the main purpose of this PR is to support other Rundeck resource models (eg. Foreman) by generating temporary inventory files.
Origin of this PR are changes from #97 - we used it for a while, but it got closed.