### PR TITLE
Dockerfile edits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk --no-cache add sudo bash ca-certificates curl openjdk8-jre openssl py-pi
   ${PROJECT_BASE}/acls \
   ${PROJECT_BASE}/etc \
   ${RDECK_BASE}/libext && \
-  curl -SLo ${RDECK_JAR} http://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.5.jar
+  curl -SLo ${RDECK_JAR} http://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.6.jar
 
 COPY docker/realm.properties ${RDECK_BASE}/server/config/
 COPY docker/run.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,11 @@ MAINTAINER David Kirstein <dak@batix.com>
 # https://github.com/William-Yeh/docker-ansible
 
 ENV ANSIBLE_HOST_KEY_CHECKING=false
+ENV RDECK_BASE=/opt/rundeck
 ENV MANPATH=${MANPATH}:${RDECK_BASE}/docs/man
 ENV PATH=${PATH}:${RDECK_BASE}/tools/bin
 ENV PROJECT_BASE=${RDECK_BASE}/projects/Test-Project
 ENV RDECK_ADMIN_PASS=rdtest2017
-ENV RDECK_BASE=/opt/rundeck
 ENV RDECK_HOST=localhost
 ENV RDECK_JAR=${RDECK_BASE}/rundeck-launcher.jar
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,13 +14,6 @@ ENV RDECK_ADMIN_PASS=rdtest2017
 ENV RDECK_HOST=localhost
 ENV RDECK_JAR=${RDECK_BASE}/rundeck-launcher.jar
 
-COPY docker/realm.properties ${RDECK_BASE}/server/config/
-COPY docker/run.sh /
-# install locally built plugin
-COPY build/libs/ansible-plugin-*.jar ${RDECK_BASE}/libext/
-# create project
-COPY docker/project.properties ${PROJECT_BASE}/etc/
-
 # install Ansible and Java, Rundeck via launcher, create directories
 # check newest version: https://pypi.python.org/pypi/ansible http://rundeck.org/downloads.html
 RUN apk --no-cache add sudo bash ca-certificates curl openjdk8-jre openssl py-pip python sudo && \
@@ -34,6 +27,13 @@ RUN apk --no-cache add sudo bash ca-certificates curl openjdk8-jre openssl py-pi
   ${RDECK_BASE}/libext && \
   curl -SLo ${RDECK_JAR} http://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.5.jar && \
   chmod +x /run.sh
+
+COPY docker/realm.properties ${RDECK_BASE}/server/config/
+COPY docker/run.sh /
+# create project
+COPY docker/project.properties ${PROJECT_BASE}/etc/
+# install locally built plugin
+COPY build/libs/ansible-plugin-*.jar ${RDECK_BASE}/libext/
 
 # install plugin from GitHub
 # check newest version: https://github.com/Batix/rundeck-ansible-plugin/releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,8 +25,7 @@ RUN apk --no-cache add sudo bash ca-certificates curl openjdk8-jre openssl py-pi
   ${PROJECT_BASE}/acls \
   ${PROJECT_BASE}/etc \
   ${RDECK_BASE}/libext && \
-  curl -SLo ${RDECK_JAR} http://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.5.jar && \
-  chmod +x /run.sh
+  curl -SLo ${RDECK_JAR} http://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.5.jar
 
 COPY docker/realm.properties ${RDECK_BASE}/server/config/
 COPY docker/run.sh /
@@ -34,6 +33,8 @@ COPY docker/run.sh /
 COPY docker/project.properties ${PROJECT_BASE}/etc/
 # install locally built plugin
 COPY build/libs/ansible-plugin-*.jar ${RDECK_BASE}/libext/
+
+RUN chmod +x /run.sh
 
 # install plugin from GitHub
 # check newest version: https://github.com/Batix/rundeck-ansible-plugin/releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,4 @@ COPY build/libs/ansible-plugin-*.jar ${RDECK_BASE}/libext/
 
 RUN chmod +x /run.sh
 
-# install plugin from GitHub
-# check newest version: https://github.com/Batix/rundeck-ansible-plugin/releases
-#RUN curl -SLo ${RDECK_BASE}/libext/ansible-plugin.jar https://github.com/Batix/rundeck-ansible-plugin/releases/download/2.1.0/ansible-plugin-2.1.0.jar
-
 CMD /run.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN apk --no-cache add sudo bash ca-certificates curl openjdk8-jre openssl py-pi
   ${PROJECT_BASE}/acls \
   ${PROJECT_BASE}/etc \
   ${RDECK_BASE}/libext && \
-  curl -SLo ${RDECK_JAR} http://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.2.jar && \
+  curl -SLo ${RDECK_JAR} http://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.5.jar && \
   chmod +x /run.sh
 
 # install plugin from GitHub

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN apk --no-cache add sudo bash ca-certificates curl openjdk8-jre openssl py-pi
   ${PROJECT_BASE}/acls \
   ${PROJECT_BASE}/etc \
   ${RDECK_BASE}/libext && \
-  curl -SLo ${RDECK_JAR} http://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.6.jar
+  curl -SLo ${RDECK_JAR} https://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.6.jar
 
 COPY docker/realm.properties ${RDECK_BASE}/server/config/
 COPY docker/run.sh /

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,15 @@ ENV RDECK_ADMIN_PASS=rdtest2017
 ENV RDECK_HOST=localhost
 ENV RDECK_JAR=${RDECK_BASE}/rundeck-launcher.jar
 
-# install Ansible and Java, create directories
-# check newest version: https://pypi.python.org/pypi/ansible
+COPY docker/realm.properties ${RDECK_BASE}/server/config/
+COPY docker/run.sh /
+# install locally built plugin
+COPY build/libs/ansible-plugin-*.jar ${RDECK_BASE}/libext/
+# create project
+COPY docker/project.properties ${PROJECT_BASE}/etc/
+
+# install Ansible and Java, Rundeck via launcher, create directories
+# check newest version: https://pypi.python.org/pypi/ansible http://rundeck.org/downloads.html
 RUN apk --no-cache add sudo bash ca-certificates curl openjdk8-jre openssl py-pip python sudo && \
   apk --no-cache add --virtual build-deps build-base libffi-dev openssl-dev python-dev && \
   pip --no-cache-dir install --upgrade cffi pip && \
@@ -24,23 +31,12 @@ RUN apk --no-cache add sudo bash ca-certificates curl openjdk8-jre openssl py-pi
   mkdir -p /etc/ansible \
   ${PROJECT_BASE}/acls \
   ${PROJECT_BASE}/etc \
-  ${RDECK_BASE}/libext
-
-# install Rundeck via launcher
-# check newest version: http://rundeck.org/downloads.html
-RUN curl -SLo ${RDECK_JAR} http://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.2.jar
-COPY docker/realm.properties ${RDECK_BASE}/server/config/
-COPY docker/run.sh /
-RUN chmod +x /run.sh
+  ${RDECK_BASE}/libext && \
+  curl -SLo ${RDECK_JAR} http://dl.bintray.com/rundeck/rundeck-maven/rundeck-launcher-2.10.2.jar && \
+  chmod +x /run.sh
 
 # install plugin from GitHub
 # check newest version: https://github.com/Batix/rundeck-ansible-plugin/releases
 #RUN curl -SLo ${RDECK_BASE}/libext/ansible-plugin.jar https://github.com/Batix/rundeck-ansible-plugin/releases/download/2.1.0/ansible-plugin-2.1.0.jar
-
-# install locally built plugin
-COPY build/libs/ansible-plugin-*.jar ${RDECK_BASE}/libext/
-
-# create project
-COPY docker/project.properties ${PROJECT_BASE}/etc/
 
 CMD /run.sh


### PR DESCRIPTION
- PR #167 inadvertently introduced incorrect order of variables - `RDECK_BASE` must be defined before others
- Bump Rundeck version to newest 2.10.6 from 05.02.2018
- Further optimizations - 2 RUN statements merged into 1