### PR TITLE
Changes parsing of disable-limit to treat as bool

### DIFF
--- a/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleRunnerBuilder.java
@@ -686,17 +686,17 @@ public class AnsibleRunnerBuilder {
         return inventory;
     }
 
-    public String getLimit() {
+    public String getLimit() throws ConfigurationException {
         final String limit;
 
         // Return Null if Disabled
-        if("true".equals(PropertyResolver.resolveProperty(
+        if(PropertyResolver.resolveBooleanProperty(
         				AnsibleDescribable.ANSIBLE_DISABLE_LIMIT,
-        				null,
+        				Boolean.valueOf(AnsibleDescribable.DISABLE_LIMIT_PROP.getDefaultValue()),
     				    getFrameworkProject(),
                         getFramework(),
                         getNode(),
-                        getjobConf()))){
+                        getjobConf())){
 
         	return null;
         }


### PR DESCRIPTION
While debugging why the `ansible-disable-limit` property (`resources.source.{n}.config.ansible-disable-limit`)  does not resolve in a workflow step, I came across this line, which seemed to be parsing the boolean property as a string.