### PR TITLE
Fix fact playbook when "become=true" in ansible.cfg

### DIFF
--- a/src/main/resources/gather-hosts.yml
+++ b/src/main/resources/gather-hosts.yml
@@ -1,9 +1,23 @@
 ---
 - hosts: all
+
   vars:
     facts: True
-  gather_facts: "{{facts}}"
+
+  gather_facts: "{{ facts }}"
+
   tasks:
-    - local_action: file path="{{tmpdir}}/data" state=directory
+    - name: "Ensure tmpdir data directory"
+      file:
+        path: "{{ tmpdir }}/data"
+        state: directory
+      become: no
       run_once: yes
-    - local_action: template src=host-tpl.j2 dest="{{tmpdir}}/data/{{inventory_hostname}}"
+      delegate_to: localhost
+
+    - name: "Template the gathered facts"
+      template:
+        src: host-tpl.j2
+        dest: "{{ tmpdir }}/data/{{ inventory_hostname }"
+      delegate_to: localhost
+      become: no


### PR DESCRIPTION
gather-hosts.yml creates files owned by root when the ansible.cfg contains "become: true". By setting "become: no" on the task level the files are created by the rundeck user.
+
new syntax