### PR TITLE
docker HTTP port fix

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -7,4 +7,4 @@ fi
 
 sed -i -e "s/_ADMINPW_/${RDECK_ADMIN_PASS}/" ${RDECK_BASE}/server/config/realm.properties
 
-java -Xmx1g "-Dserver.hostname=${RDECK_HOST}" "-Dserver.http.port=${RDECK_PORT}" -jar "${RDECK_BASE}/${RDECK_WAR}"
+java -Xmx1g "-Dserver.hostname=${RDECK_HOST}" "-Dserver.http.port=${RDECK_PORT}" "-Dserver.port=${RDECK_PORT}" -jar "${RDECK_BASE}/${RDECK_WAR}"


### PR DESCRIPTION
For Rundeck 3 and greater, it seems the HTTP server port option is changed. Updated to set both HTTP port options.