### PR TITLE
added proxy support for gradle.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,9 +21,24 @@ repositories {
   mavenCentral()
 }
 
+task setHttpProxyFromEnv {
+    def map = ['HTTP_PROXY': 'http', 'HTTPS_PROXY': 'https']
+    for (e in System.getenv()) {
+        def key = e.key.toUpperCase()
+        if (key in map) {
+            def base = map[key]
+            def url = e.value.toURL()
+            println " - systemProp.${base}.proxy=${url.host}:${url.port}"
+            System.setProperty("${base}.proxyHost", url.host.toString())
+            System.setProperty("${base}.proxyPort", url.port.toString())
+        }
+    }
+}
+
 configurations {
   pluginLibs
 
+  build.dependsOn setHttpProxyFromEnv
   compile {
     extendsFrom pluginLibs
   }


### PR DESCRIPTION
proxy is only used when a system wide proxy is supplied
via env variables HTTP_PROXY or HTTPS_PROXY like it is common on OSX and Linux

If no variable is set, all works without proxy.
This change my save guys some time to figure out how to do gradle build when beeing behind a cooperate proxy.