### PR TITLE
Add Host Groups from Tags to generated AnsibleInventory file resolves #244

### DIFF
--- a/src/main/java/com/batix/rundeck/core/AnsibleInventory.java
+++ b/src/main/java/com/batix/rundeck/core/AnsibleInventory.java
@@ -38,11 +38,13 @@ public class AnsibleInventory {
     all.addHost(nodeName, host, attributes);
     // Create Ansible groups by attribute
     // Group by osFamily is needed for windows hosts setup
-    String[] attributeGroups = { "osFamily" };
+    String[] attributeGroups = { "osFamily", "tags" };
     for (String g: attributeGroups) {
       if (attributes.containsKey(g)) {
-        String groupName = attributes.get(g).toLowerCase();
-        all.getOrAddChildHostGroup(groupName).addHost(nodeName);
+        String[] groupNames = attributes.get(g).toLowerCase().split(",");
+        for (String groupName: groupNames) {
+          all.getOrAddChildHostGroup(groupName.trim()).addHost(nodeName);
+        }
       }
     }
     return this;


### PR DESCRIPTION
All TAGS from Nodes are added as host's groups in the Ansible Inventory generated files.

This makes the hosts property for playbooks to be compliant with how ansible playbooks should work.

Also it gives the ability to create a job which selects hosts from different groups but takes different actions on the different groups.

Resolves #244 