### PR TITLE
added ability to import ansible_port if set on the inventory file

### DIFF
--- a/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
+++ b/src/main/java/com/batix/rundeck/plugins/AnsibleResourceModelSource.java
@@ -293,9 +293,21 @@ public class AnsibleResourceModelSource implements ResourceModelSource {
             System.out.println("[warn] Problem getting the ansible_host attribute from node " + hostname);
           }
 
-          String nodename = root.get("inventory_hostname").getAsString();
+          String port = root.get("inventory_hostname").getAsString();
+          try {
+            if (root.has("ansible_port")) {
+              port = root.get("ansible_port").getAsString();
+            } else { // fallback to default ssh port
+              port = "22";
+            }
+          }catch(Exception ex){
+            System.out.println("[warn] Problem getting the ansible_port attribute from node " + port);
+          }
 
-          node.setHostname(hostname);
+          String nodename = root.get("inventory_hostname").getAsString();
+          String hostname_with_port  = hostname + ":" + port;
+
+          node.setHostname(hostname_with_port);
           node.setNodename(nodename);
 
           String username = System.getProperty("user.name"); // TODO better default?


### PR DESCRIPTION
Hi all,

I have the need when importing hosts from the ansible inventory file to also set custom ssh ports per host, since this feature was not available i made the following changes, my code is perhaps not the best, feel free to propose / change anything if needed.

Introduced changes:
When using ansible inventory files with different ssh ports per host defined within the ansible_port option the plugin was not importing that into rundeck, according to rundeck documentation it is expecting the following format:

`hostname:port`

The proposed change reads, if set, the ansible_port value from the inventory file and change the hostname to defined format, if not set defaults back to port 22.

