### PR TITLE
RSE-793 (Ansible plugin) Fix: Generate inventory in node step.

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
@@ -55,6 +55,7 @@ public class AnsiblePlaybookInlineWorkflowNodeStep implements NodeStepPlugin, An
         builder.property(BECOME_AUTH_TYPE_PROP);
         builder.property(BECOME_USER_PROP);
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
+        builder.property(GENERATE_INVENTORY_PROP);
 
         DESC=builder.build();
     }


### PR DESCRIPTION
# RSE-793 (Ansible plugin) Fix: Generate inventory in node step.
Part of a bundle of solutions to fix the main problem: 'AnsiblePlaybookInlineWorkflowNodeStep' plugin could not execute remote nodes through runner.

# The Problem
The plugin was not creating the inventory during the execution (fixed with this PR)

# The solution
Set the property "ansible-generate-inventory" to be user managed through plugin definition.

## WIP, still trying to figure out how to pass the prop from the node executor w/o touching the plugin.