### PR TITLE
Fixing ANSIBLE_BINARIES_DIR_PATH resolution

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
@@ -811,14 +811,15 @@ public class AnsibleRunnerBuilder {
     }
 
     public String getBinariesFilePath() {
-        String binariesFilePathStr = PropertyResolver.resolveProperty(
-        		AnsibleDescribable.ANSIBLE_BINARIES_DIR_PATH,
-	                null,
-	                getFrameworkProject(),
-	                getFramework(),
-	                getNode(),
-	                getjobConf()
-	                );
+        String binariesFilePathStr;
+	binariesFilePathStr = PropertyResolver.resolveProperty(
+		AnsibleDescribable.ANSIBLE_BINARIES_DIR_PATH,
+		null,
+		getFrameworkProject(),
+		getFramework(),
+		getNode(),
+		getjobConf()
+		);
 	    
         // Object projectConfBinariesFilePath = getFrameworkProject().get(AnsibleDescribable.ANSIBLE_BINARIES_DIR_PATH);
         // if (null != projectConfBinariesFilePath) {

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
@@ -694,9 +694,6 @@ public class AnsibleRunnerBuilder {
                     getjobConf()
                     );
 
-        if (null != extraVars && extraVars.contains("${")) {
-            return DataContextUtils.replaceDataReferences(extraVars, getContext().getDataContext());
-        }
 	try{
 		extraVars += System.lineSeparator() + "ansible_jobConf_binaries = " + getjobConf().get(AnsibleDescribable.ANSIBLE_EXTRA_VARS);
 	}
@@ -709,6 +706,10 @@ public class AnsibleRunnerBuilder {
 	catch (Exception e){
 		extraVars += System.lineSeparator() + "ansible_projectConf_binaries = not_set";
 	}
+	    
+        if (null != extraVars && extraVars.contains("${")) {
+            return DataContextUtils.replaceDataReferences(extraVars, getContext().getDataContext());
+        }
         return extraVars;
     }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
@@ -819,24 +819,7 @@ public class AnsibleRunnerBuilder {
 		getFramework(),
 		getNode(),
 		getjobConf()
-		);
-	    
-        // Object projectConfBinariesFilePath = getFrameworkProject().get(AnsibleDescribable.ANSIBLE_BINARIES_DIR_PATH);
-        // if (null != projectConfBinariesFilePath) {
-        //     binariesFilePathStr = (String) projectConfBinariesFilePath;
-        //     if (binariesFilePathStr.contains("${")) {
-        //         return DataContextUtils.replaceDataReferences(binariesFilePathStr, getContext().getDataContext());
-        //     }
-        // }
-	    
-        // Object jobConfBinariesFilePath = getjobConf().get(AnsibleDescribable.ANSIBLE_BINARIES_DIR_PATH);
-        // if (null != jobConfBinariesFilePath) {
-        //     binariesFilePathStr = (String) jobConfBinariesFilePath;
-        //     if (binariesFilePathStr.contains("${")) {
-        //         return DataContextUtils.replaceDataReferences(binariesFilePathStr, getContext().getDataContext());
-        //     }
-        // }
-	
+		);	
         return binariesFilePathStr;
     }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
@@ -811,14 +811,31 @@ public class AnsibleRunnerBuilder {
     }
 
     public String getBinariesFilePath() {
-        String binariesFilePathStr = null;
-        Object binariesFilePath = getjobConf().get(AnsibleDescribable.ANSIBLE_BINARIES_DIR_PATH);
-        if (null != binariesFilePath) {
-            binariesFilePathStr = (String) binariesFilePath;
-            if (binariesFilePathStr.contains("${")) {
-                return DataContextUtils.replaceDataReferences(binariesFilePathStr, getContext().getDataContext());
-            }
-        }
+        String binariesFilePathStr = PropertyResolver.resolveProperty(
+        		AnsibleDescribable.ANSIBLE_BINARIES_DIR_PATH,
+	                null,
+	                getFrameworkProject(),
+	                getFramework(),
+	                getNode(),
+	                getjobConf()
+	                );
+	    
+        // Object projectConfBinariesFilePath = getFrameworkProject().get(AnsibleDescribable.ANSIBLE_BINARIES_DIR_PATH);
+        // if (null != projectConfBinariesFilePath) {
+        //     binariesFilePathStr = (String) projectConfBinariesFilePath;
+        //     if (binariesFilePathStr.contains("${")) {
+        //         return DataContextUtils.replaceDataReferences(binariesFilePathStr, getContext().getDataContext());
+        //     }
+        // }
+	    
+        // Object jobConfBinariesFilePath = getjobConf().get(AnsibleDescribable.ANSIBLE_BINARIES_DIR_PATH);
+        // if (null != jobConfBinariesFilePath) {
+        //     binariesFilePathStr = (String) jobConfBinariesFilePath;
+        //     if (binariesFilePathStr.contains("${")) {
+        //         return DataContextUtils.replaceDataReferences(binariesFilePathStr, getContext().getDataContext());
+        //     }
+        // }
+	
         return binariesFilePathStr;
     }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
@@ -820,6 +820,11 @@ public class AnsibleRunnerBuilder {
 		getNode(),
 		getjobConf()
 		);	
+        if (null != binariesFilePathStr) {
+            if (binariesFilePathStr.contains("${")) {
+                return DataContextUtils.replaceDataReferences(binariesFilePathStr, getContext().getDataContext());
+            }
+        }
         return binariesFilePathStr;
     }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
@@ -666,8 +666,25 @@ public class AnsibleRunnerBuilder {
         return ignoreTagsPrefix;
     }
 
+    // public String getExtraVars() {
+    //     final String extraVars;
+    //     extraVars = PropertyResolver.resolveProperty(
+    //                 AnsibleDescribable.ANSIBLE_EXTRA_VARS,
+    //                 null,
+    //                 getFrameworkProject(),
+    //                 getFramework(),
+    //                 getNode(),
+    //                 getjobConf()
+    //                 );
+
+    //     if (null != extraVars && extraVars.contains("${")) {
+    //         return DataContextUtils.replaceDataReferences(extraVars, getContext().getDataContext());
+    //     }
+    //     return extraVars;
+    // }
+
     public String getExtraVars() {
-        final String extraVars;
+        String extraVars = "";
         extraVars = PropertyResolver.resolveProperty(
                     AnsibleDescribable.ANSIBLE_EXTRA_VARS,
                     null,
@@ -680,6 +697,18 @@ public class AnsibleRunnerBuilder {
         if (null != extraVars && extraVars.contains("${")) {
             return DataContextUtils.replaceDataReferences(extraVars, getContext().getDataContext());
         }
+	try{
+		extraVars += System.lineSeparator() + "ansible_jobConf_binaries = " + getjobConf().get(AnsibleDescribable.ANSIBLE_EXTRA_VARS);
+	}
+	catch (Exception e){
+		extraVars += System.lineSeparator() + "ansible_jobConf_binaries = not_set";
+	}
+	try{
+		extraVars += System.lineSeparator() + "ansible_projectConf_binaries = " + getFramework().getProjectProperty(getFrameworkProject(), AnsibleDescribable.PROJ_PROP_PREFIX + attribute);
+	}
+	catch (Exception e){
+		extraVars += System.lineSeparator() + "ansible_projectConf_binaries = not_set";
+	}
         return extraVars;
     }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
@@ -666,25 +666,8 @@ public class AnsibleRunnerBuilder {
         return ignoreTagsPrefix;
     }
 
-    // public String getExtraVars() {
-    //     final String extraVars;
-    //     extraVars = PropertyResolver.resolveProperty(
-    //                 AnsibleDescribable.ANSIBLE_EXTRA_VARS,
-    //                 null,
-    //                 getFrameworkProject(),
-    //                 getFramework(),
-    //                 getNode(),
-    //                 getjobConf()
-    //                 );
-
-    //     if (null != extraVars && extraVars.contains("${")) {
-    //         return DataContextUtils.replaceDataReferences(extraVars, getContext().getDataContext());
-    //     }
-    //     return extraVars;
-    // }
-
     public String getExtraVars() {
-        String extraVars = "";
+        final String extraVars;
         extraVars = PropertyResolver.resolveProperty(
                     AnsibleDescribable.ANSIBLE_EXTRA_VARS,
                     null,
@@ -694,19 +677,6 @@ public class AnsibleRunnerBuilder {
                     getjobConf()
                     );
 
-	try{
-		extraVars += System.lineSeparator() + "ansible_jobConf_binaries = " + getjobConf().get(AnsibleDescribable.ANSIBLE_EXTRA_VARS);
-	}
-	catch (Exception e){
-		extraVars += System.lineSeparator() + "ansible_jobConf_binaries = not_set";
-	}
-	try{
-		extraVars += System.lineSeparator() + "ansible_projectConf_binaries = " + getFramework().getProjectProperty(getFrameworkProject(), AnsibleDescribable.PROJ_PROP_PREFIX + AnsibleDescribable.ANSIBLE_EXTRA_VARS);
-	}
-	catch (Exception e){
-		extraVars += System.lineSeparator() + "ansible_projectConf_binaries = not_set";
-	}
-	    
         if (null != extraVars && extraVars.contains("${")) {
             return DataContextUtils.replaceDataReferences(extraVars, getContext().getDataContext());
         }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerBuilder.java
@@ -704,7 +704,7 @@ public class AnsibleRunnerBuilder {
 		extraVars += System.lineSeparator() + "ansible_jobConf_binaries = not_set";
 	}
 	try{
-		extraVars += System.lineSeparator() + "ansible_projectConf_binaries = " + getFramework().getProjectProperty(getFrameworkProject(), AnsibleDescribable.PROJ_PROP_PREFIX + attribute);
+		extraVars += System.lineSeparator() + "ansible_projectConf_binaries = " + getFramework().getProjectProperty(getFrameworkProject(), AnsibleDescribable.PROJ_PROP_PREFIX + AnsibleDescribable.ANSIBLE_EXTRA_VARS);
 	}
 	catch (Exception e){
 		extraVars += System.lineSeparator() + "ansible_projectConf_binaries = not_set";


### PR DESCRIPTION
Changed to the PropertyResolver.resolveProperty method to get the correct resolution (jobconf first, then projectconf).

#331 