### PR TITLE
Fix error message when attempting to read SSH private key from storage

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -226,7 +226,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
           String sshPrivateKey = getStorageContentString(sshPrivateKeyPath, storageTree);
           runner = runner.sshPrivateKey(sshPrivateKey);
         } catch (ConfigurationException e) {
-          throw new ResourceModelSourceException("Could not read password from storage path " + sshPasswordPath,e);
+          throw new ResourceModelSourceException("Could not read private key from storage path " + sshPrivateKeyPath,e);
         }
       }
 


### PR DESCRIPTION
The message incorrectly returns that Rundeck is trying to read a (null) password.