### PR TITLE
RSE-384 Fix: No Syntax Highlight Between Edit Sessions Ansible Plugin

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -307,7 +307,6 @@ public interface AnsibleDescribable extends Describable {
             .description("Set additional playbook YAML or JSON variables.")
             .renderingOption(StringRenderingConstants.DISPLAY_TYPE_KEY, StringRenderingConstants.DisplayType.CODE)
             .renderingOption(StringRenderingConstants.CODE_SYNTAX_MODE, "yaml")
-            .renderingOption(StringRenderingConstants.CODE_SYNTAX_SELECTABLE, true)
             .build();
 
     public static Property EXTRA_ATTRS_PROP = PropertyUtil.string(


### PR DESCRIPTION
## No Syntax Highlight Between Edit Sessions Ansible Plugin
In the inline playbook wf step plugin, is impossible to save the syntax highlight mode in the extra variables form section

## The Fix
We decided to remove the dropdown since there are only two possible variable types: JSON or YAML. 