### PR TITLE
RUN-2448: ENH: Ansible plugin performance issue

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ dependencies {
   implementation 'org.codehaus.groovy:groovy-all:3.0.15'
   pluginLibs group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.16.1'
   pluginLibs group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1'
+  implementation "org.yaml:snakeyaml:2.0"
 
   compileOnly 'org.projectlombok:lombok:1.18.30'
   annotationProcessor 'org.projectlombok:lombok:1.18.30'

--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ dependencies {
   implementation 'org.codehaus.groovy:groovy-all:3.0.15'
   pluginLibs group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.16.1'
   pluginLibs group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.16.1'
-  implementation "org.yaml:snakeyaml:2.0"
+  implementation "org.yaml:snakeyaml:2.2"
 
   compileOnly 'org.projectlombok:lombok:1.18.30'
   annotationProcessor 'org.projectlombok:lombok:1.18.30'

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -241,7 +241,7 @@ public interface AnsibleDescribable extends Describable {
     public static Property GATHER_FACTS_PROP = PropertyUtil.bool(
               ANSIBLE_GATHER_FACTS,
               "Gather Facts",
-              "Gather fresh facts before importing? (recommended)",
+              "Gather fresh facts before importing? (Not recommended for large inventories)",
               true,
               "true"
     );

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
@@ -26,9 +26,12 @@ public class AnsibleInventoryList {
 
     private AnsibleVault ansibleVault;
     private VaultPrompt vaultPrompt;
+    private List<String> limits;
+
     private File tempInternalVaultFile;
     private File tempVaultFile;
     private File vaultPromptFile;
+    private File tempLimitFile;
 
     public static final String ANSIBLE_INVENTORY = "ansible-inventory";
 
@@ -55,6 +58,7 @@ public class AnsibleInventoryList {
         List<VaultPrompt> stdinVariables = new ArrayList<>();
 
         processAnsibleVault(stdinVariables, procArgs);
+        processLimit(procArgs);
 
         if(debug){
             System.out.println("getNodeList " + procArgs);
@@ -113,6 +117,23 @@ public class AnsibleInventoryList {
             tempVaultFile = ansibleVault.getVaultPasswordScriptFile();
             procArgs.add("--vault-id");
             procArgs.add(tempVaultFile.getAbsolutePath());
+        }
+    }
+
+    private void processLimit(List<String> procArgs) throws IOException {
+        if (limits != null && limits.size() == 1) {
+            procArgs.add("-l");
+            procArgs.add(limits.get(0));
+
+        } else if (limits != null && limits.size() > 1) {
+            StringBuilder sb = new StringBuilder();
+            for (String limit : limits) {
+                sb.append(limit).append("\n");
+            }
+            tempLimitFile = AnsibleUtil.createTemporaryFile("targets", sb.toString());
+
+            procArgs.add("-l");
+            procArgs.add("@" + tempLimitFile.getAbsolutePath());
         }
     }
 }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
@@ -24,7 +24,7 @@ public class AnsibleInventoryList {
         List<String> procArgs = new ArrayList<>();
 
         procArgs.add(ANSIBLE_INVENTORY);
-        procArgs.add("-i " + inventory);
+        procArgs.add("--inventory-file" + "=" + inventory);
         procArgs.add("--list");
         procArgs.add("-y");
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
@@ -98,12 +98,12 @@ public class AnsibleInventoryList {
                 proc.destroy();
             }
             Thread.currentThread().interrupt();
-            throw new AnsibleException("ERROR: Ansible Execution Interrupted.", e, AnsibleException.AnsibleFailureReason.Interrupted);
+            throw new AnsibleException("ERROR: Ansible Execution Interrupted: " + e.getMessage(), e, AnsibleException.AnsibleFailureReason.Interrupted);
         } catch (Exception e) {
             if (proc != null) {
                 proc.destroy();
             }
-            throw new AnsibleException("ERROR: Ansible execution returned with non zero code.", e, AnsibleException.AnsibleFailureReason.Unknown);
+            throw new AnsibleException("ERROR: Ansible execution returned with non zero code: " + e.getMessage(), e, AnsibleException.AnsibleFailureReason.Unknown);
         } finally {
             if (proc != null) {
                 proc.getErrorStream().close();

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
@@ -8,13 +8,16 @@ import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Data
 @Builder
 public class AnsibleInventoryList {
 
     private String inventory;
+    private String configFile;
     private boolean debug;
 
     public static final String ANSIBLE_INVENTORY = "ansible-inventory";
@@ -22,11 +25,18 @@ public class AnsibleInventoryList {
     public String getNodeList() {
 
         List<String> procArgs = new ArrayList<>();
-
         procArgs.add(ANSIBLE_INVENTORY);
         procArgs.add("--inventory-file" + "=" + inventory);
         procArgs.add("--list");
         procArgs.add("-y");
+
+        Map<String, String> processEnvironment = new HashMap<>();
+        if (configFile != null && !configFile.isEmpty()) {
+            if (debug) {
+                System.out.println(" ANSIBLE_CONFIG: " + configFile);
+            }
+            processEnvironment.put("ANSIBLE_CONFIG", configFile);
+        }
 
         if(debug){
             System.out.println("getNodeList " + procArgs);
@@ -37,6 +47,7 @@ public class AnsibleInventoryList {
         try {
             proc = ProcessExecutor.builder().procArgs(procArgs)
                     .redirectErrorStream(true)
+                    .environmentVariables(processEnvironment)
                     .build().run();
 
             StringBuilder stringBuilder = new StringBuilder();

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
@@ -22,6 +22,10 @@ public class AnsibleInventoryList {
 
     public static final String ANSIBLE_INVENTORY = "ansible-inventory";
 
+    /**
+     * Executes Ansible command to bring all nodes from inventory
+     * @return output in yaml format
+     */
     public String getNodeList() {
 
         List<String> procArgs = new ArrayList<>();

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
@@ -1,0 +1,69 @@
+package com.rundeck.plugins.ansible.ansible;
+
+import com.rundeck.plugins.ansible.util.ProcessExecutor;
+import lombok.Builder;
+import lombok.Data;
+
+import java.io.BufferedReader;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+public class AnsibleInventoryList {
+
+    private String inventory;
+    private boolean debug;
+
+    public static final String ANSIBLE_INVENTORY = "ansible-inventory";
+
+    public String getNodeList() {
+
+        List<String> procArgs = new ArrayList<>();
+
+        procArgs.add(ANSIBLE_INVENTORY);
+        procArgs.add("-i " + inventory);
+        procArgs.add("--list");
+        procArgs.add("-y");
+
+        if(debug){
+            System.out.println("getNodeList " + procArgs);
+        }
+
+        Process proc = null;
+
+        try {
+            proc = ProcessExecutor.builder().procArgs(procArgs)
+                    .redirectErrorStream(true)
+                    .build().run();
+
+            StringBuilder stringBuilder = new StringBuilder();
+
+            final InputStream stdoutInputStream = proc.getInputStream();
+            final BufferedReader stdoutReader = new BufferedReader(new InputStreamReader(stdoutInputStream));
+
+            String line1;
+            while ((line1 = stdoutReader.readLine()) != null) {
+                stringBuilder.append(line1).append("\n");
+            }
+
+            int exitCode = proc.waitFor();
+
+            if (exitCode != 0) {
+                System.err.println("ERROR: getNodeList: " + procArgs);
+                return null;
+            }
+            return stringBuilder.toString();
+
+        } catch (Exception e) {
+            System.err.println("error getNodeList: " + e.getMessage());
+            return null;
+        } finally {
+            if (proc != null) {
+                proc.destroy();
+            }
+        }
+    }
+}

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/InventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/InventoryList.java
@@ -4,7 +4,6 @@ import com.dtolabs.rundeck.core.common.NodeEntryImpl;
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceException;
 import lombok.Data;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -20,12 +19,13 @@ public class InventoryList {
     public static final String ERROR_MISSING_FIELD = "Error: Missing tag '%s'";
     public static final String ERROR_MISSING_TAG = "Error: Not tag found among these searched: '%s'";
 
-    private Map<String, Object> all;
-
-    public static Map<String, Object> getField(Map<String, Object> tag, final String field)
-            throws ResourceModelSourceException {
-        return getMap( Optional.ofNullable(tag.get(field))
-                .orElseThrow(() -> new ResourceModelSourceException(format(ERROR_MISSING_FIELD, field))));
+    @SuppressWarnings("unchecked")
+    public static <T> T getValue(Map<String, Object> tag, final String field) {
+        Object obj = null;
+        if (Optional.ofNullable(tag.get(field)).isPresent()) {
+            obj = tag.get(field);
+        }
+        return (T) obj;
     }
 
     @SuppressWarnings("unchecked")
@@ -33,27 +33,37 @@ public class InventoryList {
         return (T) obj;
     }
 
-    public static void tagHandle(NodeTag nodetag, NodeEntryImpl node, Map<String, String> tags)
+    public static void tagHandle(NodeTag nodetag, NodeEntryImpl node, Map<String, Object> tags)
             throws ResourceModelSourceException {
         nodetag.handle(node, tags);
     }
 
-    private static String findTag(List<String> nameTags, Map<String, String> tags) {
+    private static String findTag(List<String> nameTags, Map<String, Object> tags) {
         String found = null;
         for (String nameTag : nameTags) {
             if (tags.containsKey(nameTag)) {
-                found = tags.get(nameTag);
+                Object value = tags.get(nameTag);
+                if (value instanceof String) {
+                    found = (String) value;
+                }
                 break;
             }
         }
         return found;
     }
 
+    private static String valueString(Object obj) {
+        if (obj instanceof String) {
+            return (String) obj;
+        }
+        return null;
+    }
+
     public enum NodeTag {
 
         HOSTNAME {
             @Override
-            public void handle(NodeEntryImpl node, Map<String, String> tags) throws ResourceModelSourceException{
+            public void handle(NodeEntryImpl node, Map<String, Object> tags) throws ResourceModelSourceException{
                 final List<String> hostnames = List.of("hostname", "ansible_host", "ansible_ssh_host");
                 String nameTag = InventoryList.findTag(hostnames, tags);
                 node.setHostname(Optional.ofNullable(nameTag)
@@ -62,7 +72,7 @@ public class InventoryList {
         },
         USERNAME {
             @Override
-            public void handle(NodeEntryImpl node, Map<String, String> tags) throws ResourceModelSourceException {
+            public void handle(NodeEntryImpl node, Map<String, Object> tags) throws ResourceModelSourceException {
                 final List<String> usernames = List.of("username", "ansible_user", "ansible_ssh_user", "ansible_user_id");
                 String nameTag = InventoryList.findTag(usernames, tags);
                 node.setUsername(Optional.ofNullable(nameTag)
@@ -71,7 +81,7 @@ public class InventoryList {
         },
         OS_FAMILY {
             @Override
-            public void handle(NodeEntryImpl node, Map<String, String> tags) {
+            public void handle(NodeEntryImpl node, Map<String, Object> tags) {
                 final List<String> osNames = List.of("osFamily", "ansible_os_family");
                 String nameTag = InventoryList.findTag(osNames, tags);
                 Optional.ofNullable(nameTag).ifPresent(node::setOsFamily);
@@ -79,7 +89,7 @@ public class InventoryList {
         },
         OS_NAME {
             @Override
-            public void handle(NodeEntryImpl node, Map<String, String> tags) {
+            public void handle(NodeEntryImpl node, Map<String, Object> tags) {
                 final List<String> familyNames = List.of("osName", "ansible_os_name");
                 String nameTag = InventoryList.findTag(familyNames, tags);
                 Optional.ofNullable(nameTag).ifPresent(node::setOsName);
@@ -87,7 +97,7 @@ public class InventoryList {
         },
         OS_ARCHITECTURE {
             @Override
-            public void handle(NodeEntryImpl node, Map<String, String> tags) {
+            public void handle(NodeEntryImpl node, Map<String, Object> tags) {
                 final List<String> architectureNames = List.of("osArch", "ansible_architecture");
                 String nameTag = InventoryList.findTag(architectureNames, tags);
                 Optional.ofNullable(nameTag).ifPresent(node::setOsArch);
@@ -95,13 +105,29 @@ public class InventoryList {
         },
         OS_VERSION {
             @Override
-            public void handle(NodeEntryImpl node, Map<String, String> tags) {
+            public void handle(NodeEntryImpl node, Map<String, Object> tags) {
                 final List<String> versionNames = List.of("osVersion");
                 String nameTag = InventoryList.findTag(versionNames, tags);
                 Optional.ofNullable(nameTag).ifPresent(node::setOsArch);
             }
+        },
+        DESCRIPTION {
+            @Override
+            public void handle(NodeEntryImpl node, Map<String, Object> tags) throws ResourceModelSourceException {
+                Map<String, Object> lsbMap = InventoryList.getValue(tags, "ansible_lsb");
+                if (lsbMap != null) {
+                    String desc = InventoryList.valueString(lsbMap.get("description"));
+                    Optional.ofNullable(desc).ifPresent(node::setDescription);
+                }
+                else {
+                    Optional.ofNullable(InventoryList.getValue(tags, "ansible_distribution"))
+                            .ifPresent(x -> node.setDescription(x + " "));
+                    Optional.ofNullable(InventoryList.getValue(tags, "ansible_distribution_version"))
+                            .ifPresent(x -> node.setDescription(x + " "));
+                }
+            }
         };
 
-        public abstract void handle(NodeEntryImpl node, Map<String, String> tags) throws ResourceModelSourceException;
+        public abstract void handle(NodeEntryImpl node, Map<String, Object> tags) throws ResourceModelSourceException;
     }
 }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/InventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/InventoryList.java
@@ -106,9 +106,9 @@ public class InventoryList {
         OS_VERSION {
             @Override
             public void handle(NodeEntryImpl node, Map<String, Object> tags) {
-                final List<String> versionNames = List.of("osVersion");
+                final List<String> versionNames = List.of("osVersion", "ansible_kernel");
                 String nameTag = InventoryList.findTag(versionNames, tags);
-                Optional.ofNullable(nameTag).ifPresent(node::setOsArch);
+                Optional.ofNullable(nameTag).ifPresent(node::setOsVersion);
             }
         },
         DESCRIPTION {

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/InventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/InventoryList.java
@@ -1,8 +1,11 @@
 package com.rundeck.plugins.ansible.ansible;
 
+import com.dtolabs.rundeck.core.common.NodeEntryImpl;
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceException;
 import lombok.Data;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -15,10 +18,12 @@ public class InventoryList {
     public static final String CHILDREN = "children";
     public static final String HOSTS = "hosts";
     public static final String ERROR_MISSING_FIELD = "Error: Missing tag '%s'";
+    public static final String ERROR_MISSING_TAG = "Error: Not tag found among these searched: '%s'";
 
     private Map<String, Object> all;
 
-    public static Map<String, Object> getField(Map<String, Object> tag, final String field) throws ResourceModelSourceException {
+    public static Map<String, Object> getField(Map<String, Object> tag, final String field)
+            throws ResourceModelSourceException {
         return getMap( Optional.ofNullable(tag.get(field))
                 .orElseThrow(() -> new ResourceModelSourceException(format(ERROR_MISSING_FIELD, field))));
     }
@@ -26,5 +31,77 @@ public class InventoryList {
     @SuppressWarnings("unchecked")
     public static <T> T getMap(Object obj) {
         return (T) obj;
+    }
+
+    public static void tagHandle(NodeTag nodetag, NodeEntryImpl node, Map<String, String> tags)
+            throws ResourceModelSourceException {
+        nodetag.handle(node, tags);
+    }
+
+    private static String findTag(List<String> nameTags, Map<String, String> tags) {
+        String found = null;
+        for (String nameTag : nameTags) {
+            if (tags.containsKey(nameTag)) {
+                found = tags.get(nameTag);
+                break;
+            }
+        }
+        return found;
+    }
+
+    public enum NodeTag {
+
+        HOSTNAME {
+            @Override
+            public void handle(NodeEntryImpl node, Map<String, String> tags) throws ResourceModelSourceException{
+                final List<String> hostnames = List.of("hostname", "ansible_host", "ansible_ssh_host");
+                String nameTag = InventoryList.findTag(hostnames, tags);
+                node.setHostname(Optional.ofNullable(nameTag)
+                        .orElseThrow(() -> new ResourceModelSourceException(format(ERROR_MISSING_TAG, hostnames))));
+            }
+        },
+        USERNAME {
+            @Override
+            public void handle(NodeEntryImpl node, Map<String, String> tags) throws ResourceModelSourceException {
+                final List<String> usernames = List.of("username", "ansible_user", "ansible_ssh_user", "ansible_user_id");
+                String nameTag = InventoryList.findTag(usernames, tags);
+                node.setUsername(Optional.ofNullable(nameTag)
+                        .orElseThrow(() -> new ResourceModelSourceException(format(ERROR_MISSING_TAG, usernames))));
+            }
+        },
+        OS_FAMILY {
+            @Override
+            public void handle(NodeEntryImpl node, Map<String, String> tags) {
+                final List<String> osNames = List.of("osFamily", "ansible_os_family");
+                String nameTag = InventoryList.findTag(osNames, tags);
+                Optional.ofNullable(nameTag).ifPresent(node::setOsFamily);
+            }
+        },
+        OS_NAME {
+            @Override
+            public void handle(NodeEntryImpl node, Map<String, String> tags) {
+                final List<String> familyNames = List.of("osName", "ansible_os_name");
+                String nameTag = InventoryList.findTag(familyNames, tags);
+                Optional.ofNullable(nameTag).ifPresent(node::setOsName);
+            }
+        },
+        OS_ARCHITECTURE {
+            @Override
+            public void handle(NodeEntryImpl node, Map<String, String> tags) {
+                final List<String> architectureNames = List.of("osArch", "ansible_architecture");
+                String nameTag = InventoryList.findTag(architectureNames, tags);
+                Optional.ofNullable(nameTag).ifPresent(node::setOsArch);
+            }
+        },
+        OS_VERSION {
+            @Override
+            public void handle(NodeEntryImpl node, Map<String, String> tags) {
+                final List<String> versionNames = List.of("osVersion");
+                String nameTag = InventoryList.findTag(versionNames, tags);
+                Optional.ofNullable(nameTag).ifPresent(node::setOsArch);
+            }
+        };
+
+        public abstract void handle(NodeEntryImpl node, Map<String, String> tags) throws ResourceModelSourceException;
     }
 }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/InventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/InventoryList.java
@@ -100,11 +100,10 @@ public class InventoryList {
         },
         USERNAME {
             @Override
-            public void handle(NodeEntryImpl node, Map<String, Object> tags) throws ResourceModelSourceException {
+            public void handle(NodeEntryImpl node, Map<String, Object> tags) {
                 final List<String> usernames = List.of("username", "ansible_user", "ansible_ssh_user", "ansible_user_id");
                 String nameTag = InventoryList.findTag(usernames, tags);
-                node.setUsername(Optional.ofNullable(nameTag)
-                        .orElseThrow(() -> new ResourceModelSourceException(format(ERROR_MISSING_TAG, usernames))));
+                Optional.ofNullable(nameTag).ifPresent(node::setUsername);
             }
         },
         OS_FAMILY {

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/InventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/InventoryList.java
@@ -1,0 +1,30 @@
+package com.rundeck.plugins.ansible.ansible;
+
+import com.dtolabs.rundeck.core.resources.ResourceModelSourceException;
+import lombok.Data;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static java.lang.String.format;
+
+@Data
+public class InventoryList {
+
+    public static final String ALL = "all";
+    public static final String CHILDREN = "children";
+    public static final String HOSTS = "hosts";
+    public static final String ERROR_MISSING_FIELD = "Error: Missing tag '%s'";
+
+    private Map<String, Object> all;
+
+    public static Map<String, Object> getField(Map<String, Object> tag, final String field) throws ResourceModelSourceException {
+        return getMap( Optional.ofNullable(tag.get(field))
+                .orElseThrow(() -> new ResourceModelSourceException(format(ERROR_MISSING_FIELD, field))));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static <T> T getMap(Object obj) {
+        return (T) obj;
+    }
+}

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -367,9 +367,6 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
   public INodeSet getNodes() throws ResourceModelSourceException {
     NodeSetImpl nodes = new NodeSetImpl();
 
-    // ansible-inventory -i inventory.yaml --list -y
-    // snake yaml
-
     if (gatherFacts) {
       processWithGatherFacts(nodes);
     } else {

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -114,9 +114,14 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
 
   protected boolean encryptExtraVars = false;
 
+  private AnsibleInventoryList.AnsibleInventoryListBuilder ansibleInventoryListBuilder = null;
 
   public AnsibleResourceModelSource(final Framework framework) {
       this.framework = framework;
+  }
+
+  public void setAnsibleInventoryListBuilder(AnsibleInventoryList.AnsibleInventoryListBuilder builder) {
+    this.ansibleInventoryListBuilder = builder;
   }
 
   private static String resolveProperty(
@@ -661,13 +666,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
   public void ansibleInventoryList(NodeSetImpl nodes) throws ResourceModelSourceException {
     Yaml yaml = new Yaml();
 
-    AnsibleInventoryList inventoryList = AnsibleInventoryList.builder()
-            .inventory(inventory)
-            .configFile(configFile)
-            .debug(debug)
-            .build();
-
-    String listResp = inventoryList.getNodeList();
+    String listResp = getNodesFromInventory();
 
     Map<String, Object> allInventory = yaml.load(listResp);
     Map<String, Object> all = InventoryList.getValue(allInventory, ALL);
@@ -695,6 +694,23 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
         nodes.putNode(node);
       }
     }
+  }
+
+  /**
+   * Gets Ansible nodes from inventory
+   * @return Ansible nodes
+   */
+  public String getNodesFromInventory() {
+
+    if (this.ansibleInventoryListBuilder == null) {
+      this.ansibleInventoryListBuilder = AnsibleInventoryList.builder()
+              .inventory(inventory)
+              .configFile(configFile)
+              .debug(debug);
+    }
+    AnsibleInventoryList inventoryList = this.ansibleInventoryListBuilder.build();
+
+    return inventoryList.getNodeList();
   }
 
   private String getStorageContentString(String storagePath, StorageTree storageTree) throws ConfigurationException {

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -723,7 +723,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
       ansibleInventoryListBuilder.vaultPrompt(vaultPrompt);
     }
 
-    if (!runner.getLimits().isEmpty()) {
+    if (runner.getLimits() != null) {
       ansibleInventoryListBuilder.limits(runner.getLimits());
     }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -421,7 +421,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
     try {
       runner.run();
     } catch (Exception e) {
-      throw new ResourceModelSourceException(e.getMessage(),e);
+      throw new ResourceModelSourceException("Failed Ansible Runner execution",e);
     }
 
     try {

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -189,7 +189,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
        try {
           sshTimeout =  Integer.parseInt(str_sshTimeout);
        } catch (NumberFormatException e) {
-          throw new ConfigurationException("Can't parse timeout value : " + e.getMessage());
+          throw new ConfigurationException("Can't parse timeout value : " + e.getMessage(), e);
        }
     }
 
@@ -247,7 +247,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
         try {
           sshPrivateKey = new String(Files.readAllBytes(Paths.get(sshPrivateKeyFile)));
         } catch (IOException e) {
-          throw new ResourceModelSourceException("Could not read privatekey file " + sshPrivateKeyFile,e);
+          throw new ResourceModelSourceException("Could not read privatekey file " + sshPrivateKeyFile +": "+ e.getMessage(),e);
         }
         runnerBuilder.sshPrivateKey(sshPrivateKey);
       }
@@ -257,7 +257,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
           String sshPrivateKey = getStorageContentString(sshPrivateKeyPath, storageTree);
           runnerBuilder.sshPrivateKey(sshPrivateKey);
         } catch (ConfigurationException e) {
-          throw new ResourceModelSourceException("Could not read private key from storage path " + sshPrivateKeyPath,e);
+          throw new ResourceModelSourceException("Could not read private key from storage path " + sshPrivateKeyPath +": "+ e.getMessage(),e);
         }
       }
 
@@ -269,7 +269,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
             String sshPassphrase = getStorageContentString(sshPassphraseStoragePath, storageTree);
             runnerBuilder.sshPassphrase(sshPassphrase);
           } catch (ConfigurationException e) {
-            throw new ResourceModelSourceException("Could not read passphrase from storage path " + sshPassphraseStoragePath,e);
+            throw new ResourceModelSourceException("Could not read passphrase from storage path " + sshPassphraseStoragePath +": "+ e.getMessage(),e);
           }
         }
       }
@@ -284,7 +284,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
           sshPassword = getStorageContentString(sshPasswordPath, storageTree);
           runnerBuilder.sshUsePassword(Boolean.TRUE).sshPass(sshPassword);
         } catch (ConfigurationException e) {
-          throw new ResourceModelSourceException("Could not read password from storage path " + sshPasswordPath,e);
+          throw new ResourceModelSourceException("Could not read password from storage path " + sshPasswordPath +": "+ e.getMessage(),e);
         }
       }
     }
@@ -325,7 +325,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
         becomePassword = getStorageContentString(becamePasswordStoragePath, storageTree);
         runnerBuilder.becomePassword(becomePassword);
       } catch (Exception e) {
-        throw new ResourceModelSourceException("Could not read becomePassword from storage path " + becamePasswordStoragePath,e);
+        throw new ResourceModelSourceException("Could not read becomePassword from storage path " + becamePasswordStoragePath +": "+ e.getMessage(),e);
       }
     }
 
@@ -341,7 +341,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
       try {
         vaultPassword = getStorageContentString(vaultPasswordPath, storageTree);
       } catch (Exception e) {
-        throw new ResourceModelSourceException("Could not read vaultPassword " + vaultPasswordPath,e);
+        throw new ResourceModelSourceException("Could not read vaultPassword " + vaultPasswordPath +": "+ e.getMessage(),e);
       }
       runnerBuilder.vaultPass(vaultPassword);
     }
@@ -351,7 +351,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
       try {
         vaultPassword = new String(Files.readAllBytes(Paths.get(vaultFile)));
       } catch (IOException e) {
-        throw new ResourceModelSourceException("Could not read vault file " + vaultFile,e);
+        throw new ResourceModelSourceException("Could not read vault file " + vaultFile +": "+ e.getMessage(),e);
       }
       runnerBuilder.vaultPass(vaultPassword);
     }
@@ -421,7 +421,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
     try {
       runner.run();
     } catch (Exception e) {
-      throw new ResourceModelSourceException("Failed Ansible Runner execution",e);
+      throw new ResourceModelSourceException("Failed Ansible Runner execution: " + e.getMessage(),e);
     }
 
     try {
@@ -641,7 +641,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
         directoryStream.close();
       }
     } catch (IOException e) {
-      throw new ResourceModelSourceException("Error reading facts.", e);
+      throw new ResourceModelSourceException("Error reading facts: " + e.getMessage(), e);
     }
 
     try {
@@ -659,7 +659,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
         }
       });
     } catch (IOException e) {
-      throw new ResourceModelSourceException("Error deleting temporary directory.", e);
+      throw new ResourceModelSourceException("Error deleting temporary directory: " + e.getMessage(), e);
     }
   }
 
@@ -733,7 +733,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
     try {
         return inventoryList.getNodeList();
     } catch (IOException | AnsibleException e) {
-      throw new ResourceModelSourceException("Failed to get node list from ansible: ", e);
+      throw new ResourceModelSourceException("Failed to get node list from ansible: " + e.getMessage(), e);
     }
   }
 
@@ -750,10 +750,10 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
       return byteArrayOutputStream.toByteArray();
     } catch (StorageException e) {
       throw new ConfigurationException("Failed to read the ssh private key for " +
-              "storage path: " + storagePath + ": " + e.getMessage());
+              "storage path: " + storagePath + ": " + e.getMessage(), e);
     } catch (IOException e) {
       throw new ConfigurationException("Failed to read the ssh private key for " +
-              "storage path: " + storagePath + ": " + e.getMessage());
+              "storage path: " + storagePath + ": " + e.getMessage(), e);
     }
   }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -351,6 +351,9 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
     NodeSetImpl nodes = new NodeSetImpl();
     final Gson gson = new Gson();
 
+    // ansible-inventory -i inventory.yaml --list
+    // snake yaml
+
     Path tempDirectory;
     try {
       tempDirectory = Files.createTempDirectory("ansible-hosts");

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -653,6 +653,11 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
     }
   }
 
+  /**
+   * Process nodes coming from Ansible to convert them to Rundeck node
+   * @param nodes Rundeck nodes
+   * @throws ResourceModelSourceException
+   */
   public void ansibleInventoryList(NodeSetImpl nodes) throws ResourceModelSourceException {
     Yaml yaml = new Yaml();
 
@@ -670,7 +675,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
 
     for (Map.Entry<String, Object> pair : children.entrySet()) {
       String hostGroup = pair.getKey();
-      Map<String, Object> hostNames = InventoryList.getMap(pair.getValue());
+      Map<String, Object> hostNames = InventoryList.getType(pair.getValue());
       Map<String, Object> hosts = InventoryList.getValue(hostNames, HOSTS);
 
       for (Map.Entry<String, Object> hostNode : hosts.entrySet()) {
@@ -679,8 +684,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
         String hostName = hostNode.getKey();
         node.setHostname(hostName);
         node.setNodename(hostName);
-        Map<String, Object> nodeValues = InventoryList.getMap(hostNode.getValue());
-        //InventoryList.tagHandle(NodeTag.HOSTNAME, node, nodeValues);
+        Map<String, Object> nodeValues = InventoryList.getType(hostNode.getValue());
         InventoryList.tagHandle(NodeTag.USERNAME, node, nodeValues);
         InventoryList.tagHandle(NodeTag.OS_FAMILY, node, nodeValues);
         InventoryList.tagHandle(NodeTag.OS_NAME, node, nodeValues);

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -20,6 +20,7 @@ import com.google.gson.JsonParser;
 import com.google.gson.JsonPrimitive;
 import com.rundeck.plugins.ansible.ansible.AnsibleDescribable;
 import com.rundeck.plugins.ansible.ansible.AnsibleDescribable.AuthenticationType;
+import com.rundeck.plugins.ansible.ansible.AnsibleException;
 import com.rundeck.plugins.ansible.ansible.AnsibleInventoryList;
 import com.rundeck.plugins.ansible.ansible.AnsibleRunner;
 import com.rundeck.plugins.ansible.ansible.InventoryList;
@@ -399,7 +400,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
       Files.copy(this.getClass().getClassLoader().getResourceAsStream(HOST_TPL_J2), tempDirectory.resolve(HOST_TPL_J2));
       Files.copy(this.getClass().getClassLoader().getResourceAsStream(GATHER_HOSTS_YML), tempDirectory.resolve(GATHER_HOSTS_YML));
     } catch (IOException e) {
-      throw new ResourceModelSourceException("Error copying files.");
+      throw new ResourceModelSourceException("Error copying files.", e);
     }
 
     runnerBuilder.tempDirectory(tempDirectory);
@@ -731,8 +732,8 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
 
     try {
         return inventoryList.getNodeList();
-    } catch (Exception e) {
-      throw new ResourceModelSourceException(e.getMessage(),e);
+    } catch (IOException | AnsibleException e) {
+      throw new ResourceModelSourceException("Failed to get node list from ansible: ", e);
     }
   }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -723,6 +723,10 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
       ansibleInventoryListBuilder.vaultPrompt(vaultPrompt);
     }
 
+    if (!runner.getLimits().isEmpty()) {
+      ansibleInventoryListBuilder.limits(runner.getLimits());
+    }
+
     AnsibleInventoryList inventoryList = this.ansibleInventoryListBuilder.build();
 
     try {

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -26,7 +26,9 @@ import com.rundeck.plugins.ansible.ansible.InventoryList;
 import org.rundeck.app.spi.Services;
 import org.rundeck.storage.api.PathUtil;
 import org.rundeck.storage.api.StorageException;
+import org.yaml.snakeyaml.LoaderOptions;
 import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.SafeConstructor;
 
 import java.io.BufferedReader;
 import java.io.ByteArrayOutputStream;
@@ -664,7 +666,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
    * @throws ResourceModelSourceException
    */
   public void ansibleInventoryList(NodeSetImpl nodes) throws ResourceModelSourceException {
-    Yaml yaml = new Yaml();
+    Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
 
     String listResp = getNodesFromInventory();
 
@@ -709,6 +711,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
               .debug(debug);
     }
     AnsibleInventoryList inventoryList = this.ansibleInventoryListBuilder.build();
+    //inventoryList.processVault();
 
     return inventoryList.getNodeList();
   }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -393,14 +393,14 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
     try {
       tempDirectory = Files.createTempDirectory("ansible-hosts");
     } catch (IOException e) {
-      throw new ResourceModelSourceException("Error creating temporary directory.", e);
+      throw new ResourceModelSourceException("Error creating temporary directory: " + e.getMessage(), e);
     }
 
     try {
       Files.copy(this.getClass().getClassLoader().getResourceAsStream(HOST_TPL_J2), tempDirectory.resolve(HOST_TPL_J2));
       Files.copy(this.getClass().getClassLoader().getResourceAsStream(GATHER_HOSTS_YML), tempDirectory.resolve(GATHER_HOSTS_YML));
     } catch (IOException e) {
-      throw new ResourceModelSourceException("Error copying files.", e);
+      throw new ResourceModelSourceException("Error copying files: " + e.getMessage(), e);
     }
 
     runnerBuilder.tempDirectory(tempDirectory);

--- a/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceSpec.groovy
@@ -1,0 +1,89 @@
+package com.rundeck.plugins.ansible.plugin
+
+import static com.rundeck.plugins.ansible.ansible.AnsibleInventoryList.AnsibleInventoryListBuilder
+
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.common.INodeEntry
+import com.dtolabs.rundeck.core.common.INodeSet
+import com.dtolabs.rundeck.core.resources.ResourceModelSource
+import com.rundeck.plugins.ansible.ansible.AnsibleDescribable
+import com.rundeck.plugins.ansible.ansible.AnsibleInventoryList
+import org.yaml.snakeyaml.Yaml
+import spock.lang.Specification
+
+/**
+ * AnsibleResourceModelSource test
+ */
+class AnsibleResourceModelSourceSpec extends Specification {
+
+    void "get nodes gather facts false"() {
+        given:
+        Yaml yaml = new Yaml()
+        String familyValue = 'Linux'
+        String nameValue = 'RED HAT'
+        String versionValue = "'7.9'"
+        String archValue = 'x64'
+        String usernameValue = 'test'
+        String descValue = 'CentOS Linux'
+        Framework framework = Mock(Framework) {
+            getBaseDir() >> Mock(File) {
+                getAbsolutePath() >> '/tmp'
+            }
+        }
+        ResourceModelSource plugin = new AnsibleResourceModelSource(framework)
+        Properties config = new Properties()
+        config.put('project', 'project_1')
+        config.put(AnsibleDescribable.ANSIBLE_GATHER_FACTS, 'false')
+        plugin.configure(config)
+
+        when:
+        Map<String, String> nodeData = [:]
+        if (osFamily) { nodeData.put(osFamily, familyValue) }
+        if (osName) { nodeData.put(osName, nameValue) }
+        if (osVersion) { nodeData.put(osVersion, versionValue) }
+        if (osArch) { nodeData.put(osArch, archValue) }
+        if (username) { nodeData.put(username, usernameValue) }
+        if (description) {
+            nodeData.put(description, descValue)
+        }
+
+        def host = [(nodeName) : nodeData]
+        def hosts = ['hosts' : host]
+        def groups = ['ungrouped' : hosts]
+        def children = ['children' : groups]
+        def all = ['all' : children]
+
+        String result = yaml.dump(all)
+
+        AnsibleInventoryListBuilder inventoryListBuilder = Mock(AnsibleInventoryListBuilder) {
+            build() >> Mock(AnsibleInventoryList) {
+                getNodeList() >> result
+            }
+        }
+
+        plugin.ansibleInventoryListBuilder = inventoryListBuilder
+        INodeSet nodes = plugin.getNodes()
+
+        then:
+        nodes.size() == 1
+        INodeEntry node = nodes[0]
+        node.tags.size() == 1
+        node.tags[0] == 'ungrouped'
+        if (node.hostname)    { node.hostname == nodeName }
+        if (node.nodename)    { node.nodename == nodeName }
+        if (node.osFamily)    { node.osFamily == familyValue }
+        if (node.osName)      { node.osName == nameValue }
+        if (node.osVersion)   { node.osVersion == versionValue }
+        if (node.osArch)      { node.osArch == archValue }
+        if (node.username)    { node.username == usernameValue }
+        if (node.description) { node.description == descValue }
+
+        where:
+        nodeName | osFamily            | osName            | osVersion        | osArch                 | username           | description
+        'NODE_0' | 'osFamily'          | 'osName'          | 'osVersion'      | 'osArch'               | 'username'         | 'description'
+        'NODE_1' | 'ansible_os_family' | 'ansible_os_name' | 'ansible_kernel' | 'ansible_architecture' | 'ansible_user'     | 'ansible_distribution'
+        'NODE_2' | 'ansible_os_family' | 'ansible_os_name' | 'ansible_kernel' | 'ansible_architecture' | 'ansible_ssh_user' | 'ansible_distribution'
+        'NODE_3' | 'ansible_os_family' | 'ansible_os_name' | 'ansible_kernel' | 'ansible_architecture' | 'ansible_user_id'  | 'ansible_distribution'
+    }
+
+}

--- a/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceSpec.groovy
@@ -1,5 +1,9 @@
 package com.rundeck.plugins.ansible.plugin
 
+import com.dtolabs.rundeck.core.storage.StorageTree
+import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
+import org.rundeck.app.spi.Services
+
 import static com.rundeck.plugins.ansible.ansible.AnsibleInventoryList.AnsibleInventoryListBuilder
 
 import com.dtolabs.rundeck.core.common.Framework
@@ -35,6 +39,10 @@ class AnsibleResourceModelSourceSpec extends Specification {
         config.put('project', 'project_1')
         config.put(AnsibleDescribable.ANSIBLE_GATHER_FACTS, 'false')
         plugin.configure(config)
+        Services services = Mock(Services) {
+            getService(KeyStorageTree.class) >> Mock(KeyStorageTree)
+        }
+        plugin.setServices(services)
 
         when:
         Map<String, String> nodeData = [:]


### PR DESCRIPTION
## ⛔️ Ticket:
https://pagerduty.atlassian.net/browse/RUN-2448

## ❌ Issue:
The method getNodes consume a lot CPU and RAM when it tries to process all Ansible nodes and converting them into Rundeck nodes.

## ✅ Solution:
When Gather Facts is set to false another Ansible command (ansible-inventory) is applied to bring in the nodes and convert them to Rundeck format. These nodes, now transformed, will have much less information but will not consume large CPU and RAM resources, which is what happened with the previous playbook when Gather Facts is true. In addition, in the file ansible.cfg it has to change this property to "duplicate_dict_key=ignore"

Documentation PR:
https://github.com/rundeck/docs/pull/1490