### PR TITLE
RUN-2670: Enh: Added yaml data size parameter at model source

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -534,8 +534,8 @@ public interface AnsibleDescribable extends Describable {
             .integer(ANSIBLE_YAML_DATA_SIZE)
             .required(false)
             .title("Inventory Yaml Data Size")
-            .description("Set the MB size (Default value is 10MB)"+
-                    " that the plugin can process with the yaml data response from Ansible."+
+            .description("Set the MB size (Default value is 10)"+
+                    " therefore, the plugin can process the yaml data response coming from Ansible."+
                     " (This only applies when Gather Facts = No)")
             .build();
 }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -158,6 +158,8 @@ public interface AnsibleDescribable extends Describable {
 
     public static final String ANSIBLE_ENCRYPT_EXTRA_VARS = "ansible-encrypt-extra-vars";
 
+    String ANSIBLE_YAML_DATA_SIZE = "ansible-yaml-data-size";
+
     public static Property PLAYBOOK_PATH_PROP = PropertyUtil.string(
     			ANSIBLE_PLAYBOOK_PATH,
               "Playbook",
@@ -526,5 +528,14 @@ public interface AnsibleDescribable extends Describable {
             .required(false)
             .title("Encrypt Extra Vars.")
             .description("Encrypt the value of the extra vars keys.")
+            .build();
+
+    Property YAML_DATA_SIZE_PROP = PropertyBuilder.builder()
+            .string(ANSIBLE_YAML_DATA_SIZE)
+            .required(false)
+            .title("Inventory Yaml Data Size")
+            .description("Set the MB size (Default value is 10MB)"+
+                    " that the plugin can process with the yaml data response from Ansible."+
+                    " (This only applies when Gather Facts = No)")
             .build();
 }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -531,7 +531,7 @@ public interface AnsibleDescribable extends Describable {
             .build();
 
     Property YAML_DATA_SIZE_PROP = PropertyBuilder.builder()
-            .string(ANSIBLE_YAML_DATA_SIZE)
+            .integer(ANSIBLE_YAML_DATA_SIZE)
             .required(false)
             .title("Inventory Yaml Data Size")
             .description("Set the MB size (Default value is 10MB)"+

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceFactory.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceFactory.java
@@ -35,6 +35,7 @@ public class AnsibleResourceModelSourceFactory implements ResourceModelSourceFac
         builder.property(INVENTORY_PROP);
         builder.property(CONFIG_FILE_PATH);
         builder.property(GATHER_FACTS_PROP);
+        builder.property(YAML_DATA_SIZE_PROP);
         builder.property(IGNORE_ERRORS_PROP);
         builder.property(LIMIT_PROP);
         builder.property(DISABLE_LIMIT_PROP);


### PR DESCRIPTION
## ⛔️ Ticket:
https://pagerduty.atlassian.net/browse/RUN-2670

## ✅ Description:
Add field at Ansible model source to set yaml data size coming from an inventory. The default value is 10mb.
<img width="784" alt="image" src="https://github.com/user-attachments/assets/21659543-7f25-43b8-b6b7-77522cc9295a">
