### PR TITLE
Replace ansible_ssh_user in AnsibleRunner.java for better compatibility with Windows

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -447,7 +447,7 @@ public class AnsibleRunner {
             }
 
             if (sshUsePassword) {
-                String extraVarsPassword = "ansible_ssh_password: " + sshPass;
+                String extraVarsPassword = "ansible_password: " + sshPass;
                 String finalextraVarsPassword = extraVarsPassword;
 
                 if(useAnsibleVault){


### PR DESCRIPTION
Following #392 , I have tested replacing ansible_ssh_password with ansible_password so that the encrypted extra var works with both Windows and Unix hosts.

The test was successful on both Windows and Unix hosts.

I'm not sure what else is needed to complete this pull request.


Thanks