### PR TITLE
RPL-37 Allow custom bin path on gather facts false

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
@@ -34,7 +34,7 @@ public class AnsibleInventoryList {
     private File vaultPromptFile;
     private File tempLimitFile;
 
-    public static final String ANSIBLE_INVENTORY = "/ansible-inventory";
+    public static final String ANSIBLE_INVENTORY = "ansible-inventory";
 
     /**
      * Executes Ansible command to bring all nodes from inventory
@@ -43,7 +43,10 @@ public class AnsibleInventoryList {
     public String getNodeList() throws IOException, AnsibleException {
 
         List<String> procArgs = new ArrayList<>();
-        procArgs.add(ansibleBinariesDirectoryPath+ANSIBLE_INVENTORY);
+        if(ansibleBinariesDirectoryPath!=null && !ansibleBinariesDirectoryPath.isEmpty()) {
+            procArgs.add(ansibleBinariesDirectoryPath+"/"+ANSIBLE_INVENTORY);
+        }
+        procArgs.add(ANSIBLE_INVENTORY);
         //inventory can be defined in ansible.cfg
         if(inventory!=null && !inventory.isEmpty()){
             procArgs.add("--inventory-file" + "=" + inventory);

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
@@ -21,6 +21,7 @@ import java.util.Map;
 public class AnsibleInventoryList {
 
     private String inventory;
+    private String ansibleBinariesDirectoryPath;
     private String configFile;
     private boolean debug;
 
@@ -33,7 +34,7 @@ public class AnsibleInventoryList {
     private File vaultPromptFile;
     private File tempLimitFile;
 
-    public static final String ANSIBLE_INVENTORY = "ansible-inventory";
+    public static final String ANSIBLE_INVENTORY = "/ansible-inventory";
 
     /**
      * Executes Ansible command to bring all nodes from inventory
@@ -42,7 +43,7 @@ public class AnsibleInventoryList {
     public String getNodeList() throws IOException, AnsibleException {
 
         List<String> procArgs = new ArrayList<>();
-        procArgs.add(ANSIBLE_INVENTORY);
+        procArgs.add(ansibleBinariesDirectoryPath+ANSIBLE_INVENTORY);
         //inventory can be defined in ansible.cfg
         if(inventory!=null && !inventory.isEmpty()){
             procArgs.add("--inventory-file" + "=" + inventory);

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
@@ -11,6 +11,8 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -21,7 +23,7 @@ import java.util.Map;
 public class AnsibleInventoryList {
 
     private String inventory;
-    private String ansibleBinariesDirectoryPath;
+    private Path ansibleBinariesDirectory;
     private String configFile;
     private boolean debug;
 
@@ -34,7 +36,7 @@ public class AnsibleInventoryList {
     private File vaultPromptFile;
     private File tempLimitFile;
 
-    public static final String ANSIBLE_INVENTORY = "ansible-inventory";
+    public static final String ANSIBLE_INVENTORY_COMMAND = "ansible-inventory";
 
     /**
      * Executes Ansible command to bring all nodes from inventory
@@ -43,10 +45,11 @@ public class AnsibleInventoryList {
     public String getNodeList() throws IOException, AnsibleException {
 
         List<String> procArgs = new ArrayList<>();
-        if(ansibleBinariesDirectoryPath!=null && !ansibleBinariesDirectoryPath.isEmpty()) {
-            procArgs.add(ansibleBinariesDirectoryPath+"/"+ANSIBLE_INVENTORY);
+        String ansibleCommand = ANSIBLE_INVENTORY_COMMAND;
+        if(ansibleBinariesDirectory!=null) {
+            ansibleCommand = Paths.get(ansibleBinariesDirectory.toFile().getAbsolutePath(), ansibleCommand).toFile().getAbsolutePath();
         }
-        procArgs.add(ANSIBLE_INVENTORY);
+        procArgs.add(ansibleCommand);
         //inventory can be defined in ansible.cfg
         if(inventory!=null && !inventory.isEmpty()){
             procArgs.add("--inventory-file" + "=" + inventory);

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -761,12 +761,18 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
     AnsibleRunner runner = runnerBuilder.build();
 
     if (this.ansibleInventoryListBuilder == null) {
+      if(ansibleBinariesDirectoryPath!=null && !ansibleBinariesDirectoryPath.isEmpty()){
+        this.ansibleInventoryListBuilder = AnsibleInventoryList.builder()
+                .inventory(inventory)
+                .ansibleBinariesDirectory(java.nio.file.Path.of(ansibleBinariesDirectoryPath))
+                .configFile(configFile)
+                .debug(debug);
+      }
       this.ansibleInventoryListBuilder = AnsibleInventoryList.builder()
               .inventory(inventory)
-              .ansibleBinariesDirectory(java.nio.file.Path.of(ansibleBinariesDirectoryPath))
               .configFile(configFile)
               .debug(debug);
-    }
+      }
 
     if(runner.getVaultPass() != null){
       VaultPrompt vaultPrompt = VaultPrompt.builder()

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -763,7 +763,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
     if (this.ansibleInventoryListBuilder == null) {
       this.ansibleInventoryListBuilder = AnsibleInventoryList.builder()
               .inventory(inventory)
-              .ansibleBinariesDirectoryPath(ansibleBinariesDirectoryPath)
+              .ansibleBinariesDirectory(java.nio.file.Path.of(ansibleBinariesDirectoryPath))
               .configFile(configFile)
               .debug(debug);
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -768,10 +768,12 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
                 .configFile(configFile)
                 .debug(debug);
       }
-      this.ansibleInventoryListBuilder = AnsibleInventoryList.builder()
-              .inventory(inventory)
-              .configFile(configFile)
-              .debug(debug);
+      else{
+        this.ansibleInventoryListBuilder = AnsibleInventoryList.builder()
+                .inventory(inventory)
+                .configFile(configFile)
+                .debug(debug);
+      }
       }
 
     if(runner.getVaultPass() != null){

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -761,20 +761,17 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
     AnsibleRunner runner = runnerBuilder.build();
 
     if (this.ansibleInventoryListBuilder == null) {
-      if(ansibleBinariesDirectoryPath!=null && !ansibleBinariesDirectoryPath.isEmpty()){
-        this.ansibleInventoryListBuilder = AnsibleInventoryList.builder()
-                .inventory(inventory)
-                .ansibleBinariesDirectory(java.nio.file.Path.of(ansibleBinariesDirectoryPath))
-                .configFile(configFile)
-                .debug(debug);
+      Path ansibleBinPath = null;
+      if (ansibleBinariesDirectoryPath != null && !ansibleBinariesDirectoryPath.isEmpty()) {
+        ansibleBinPath = (java.nio.file.Path.of(ansibleBinariesDirectoryPath));
       }
-      else{
-        this.ansibleInventoryListBuilder = AnsibleInventoryList.builder()
-                .inventory(inventory)
-                .configFile(configFile)
-                .debug(debug);
-      }
-      }
+
+      this.ansibleInventoryListBuilder = AnsibleInventoryList.builder()
+              .inventory(inventory)
+              .ansibleBinariesDirectory(ansibleBinPath)
+              .configFile(configFile)
+              .debug(debug);
+    }
 
     if(runner.getVaultPass() != null){
       VaultPrompt vaultPrompt = VaultPrompt.builder()

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSource.java
@@ -763,6 +763,7 @@ public class AnsibleResourceModelSource implements ResourceModelSource, ProxyRun
     if (this.ansibleInventoryListBuilder == null) {
       this.ansibleInventoryListBuilder = AnsibleInventoryList.builder()
               .inventory(inventory)
+              .ansibleBinariesDirectoryPath(ansibleBinariesDirectoryPath)
               .configFile(configFile)
               .debug(debug);
     }


### PR DESCRIPTION
Problem:
When customizing the “Ansible binaries path” and setting "Gather Facts" to "No," the Ansible resource model displays an error in the GUI.

Solution:
When "Gather Facts" is set to false, verify if the user has defined a file path for the Ansible binaries. If specified, include this path in the Ansible command used to retrieve the nodes.

Functional test:
https://github.com/rundeckpro/rundeckpro/pull/3991
