### PR TITLE
RPL-69 Enable custom tmp on ansible

### DIFF
--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInlineInventoryBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInlineInventoryBuilder.java
@@ -2,6 +2,7 @@ package com.rundeck.plugins.ansible.ansible;
 
 import com.dtolabs.rundeck.core.common.INodeEntry;
 import com.dtolabs.rundeck.core.plugins.configuration.ConfigurationException;
+import com.rundeck.plugins.ansible.util.AnsibleUtil;
 
 import java.io.File;
 import java.io.PrintWriter;
@@ -11,14 +12,16 @@ import java.util.HashMap;
 public class AnsibleInlineInventoryBuilder {
 
     private final String inline_inventory;
+    private final String customTmpDirPath;
 
-    public AnsibleInlineInventoryBuilder(String inline_inventory) {
+    public AnsibleInlineInventoryBuilder(String inline_inventory,String customTmpDirPath) {
         this.inline_inventory = inline_inventory;
+        this.customTmpDirPath = customTmpDirPath;
     }
 
     public File buildInventory() throws ConfigurationException {
         try {
-            File file = File.createTempFile("ansible-inventory", ".inventory");
+            File file = AnsibleUtil.createTemporaryFile("ansible-inventory", ".inventory","",customTmpDirPath);
             file.deleteOnExit();
             PrintWriter writer = new PrintWriter(file);
             writer.write(inline_inventory);

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryBuilder.java
@@ -10,18 +10,21 @@ import java.util.Collection;
 import java.util.HashMap;
 
 import com.google.gson.Gson;
+import com.rundeck.plugins.ansible.util.AnsibleUtil;
 
 public class AnsibleInventoryBuilder {
 
     private final Collection<INodeEntry> nodes;
+    private final String customTmpDirPath;
 
-    public AnsibleInventoryBuilder(Collection<INodeEntry> nodes) {
+    public AnsibleInventoryBuilder(Collection<INodeEntry> nodes, String customTmpDirPath ) {
         this.nodes = nodes;
+        this.customTmpDirPath = customTmpDirPath;
     }
 
     public File buildInventory() throws ConfigurationException {
         try {
-            File file = File.createTempFile("ansible-inventory", ".json");
+            File file = AnsibleUtil.createTemporaryFile("ansible-inventory", ".json","",customTmpDirPath);
             file.deleteOnExit();
             PrintWriter writer = new PrintWriter(file);
             AnsibleInventory ai = new AnsibleInventory();

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleInventoryList.java
@@ -35,6 +35,7 @@ public class AnsibleInventoryList {
     private File tempVaultFile;
     private File vaultPromptFile;
     private File tempLimitFile;
+    private String customTmpDirPath;
 
     public static final String ANSIBLE_INVENTORY_COMMAND = "ansible-inventory";
 
@@ -139,7 +140,7 @@ public class AnsibleInventoryList {
         if (vaultPrompt == null) { return; }
 
         if(ansibleVault == null){
-            tempInternalVaultFile = AnsibleVault.createVaultScriptAuth("ansible-script-vault");
+            tempInternalVaultFile = AnsibleVault.createVaultScriptAuth("ansible-script-vault",customTmpDirPath);
             ansibleVault = AnsibleVault.builder()
                     .masterPassword(vaultPrompt.getVaultPassword())
                     .vaultPasswordScriptFile(tempInternalVaultFile)
@@ -165,7 +166,7 @@ public class AnsibleInventoryList {
             for (String limit : limits) {
                 sb.append(limit).append("\n");
             }
-            tempLimitFile = AnsibleUtil.createTemporaryFile("targets", sb.toString());
+            tempLimitFile = AnsibleUtil.createTemporaryFile("","targets", sb.toString(),customTmpDirPath);
 
             procArgs.add("-l");
             procArgs.add("@" + tempLimitFile.getAbsolutePath());

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -22,6 +22,7 @@ import java.nio.file.Files;
 import java.nio.file.Paths;
 
 import com.rundeck.plugins.ansible.plugin.AnsiblePluginGroup;
+import com.rundeck.plugins.ansible.util.AnsibleUtil;
 import lombok.Getter;
 import org.rundeck.storage.api.Path;
 
@@ -605,7 +606,7 @@ public class AnsibleRunnerContextBuilder {
 
 
         if (isGenerated != null && isGenerated) {
-            File tempInventory = new AnsibleInventoryBuilder(this.nodes).buildInventory();
+            File tempInventory = new AnsibleInventoryBuilder(this.nodes, AnsibleUtil.getCustomTmpPathDir(framework)).buildInventory();
             tempFiles.add(tempInventory);
             inventory = tempInventory.getAbsolutePath();
             return inventory;
@@ -625,7 +626,7 @@ public class AnsibleRunnerContextBuilder {
             the builder gets the nodes from rundeck in rundeck node format and converts to ansible inventory
             we don't want that, we simply want the list we provided in ansible format
              */
-            File tempInventory = new AnsibleInlineInventoryBuilder(inline_inventory).buildInventory();
+            File tempInventory = new AnsibleInlineInventoryBuilder(inline_inventory,AnsibleUtil.getCustomTmpPathDir(framework)).buildInventory();
             tempFiles.add(tempInventory);
             inventory = tempInventory.getAbsolutePath();
             return inventory;

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleVault.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleVault.java
@@ -128,8 +128,8 @@ public class AnsibleVault {
     }
 
 
-    public static File createVaultScriptAuth(String suffix) throws IOException {
-        File tempInternalVaultFile = File.createTempFile("ansible-runner", suffix + "-client.py");
+    public static File createVaultScriptAuth(String suffix, String path) throws IOException {
+        File tempInternalVaultFile = AnsibleUtil.createTemporaryFile("ansible-runner", suffix + "-client.py","",path);
 
         try {
             Files.copy(AnsibleUtil.class.getClassLoader().getResourceAsStream("vault-client.py"),

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleFileCopier.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleFileCopier.java
@@ -149,6 +149,7 @@ public class AnsibleFileCopier implements FileCopier, AnsibleDescribable, ProxyR
 
     try {
         runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
+        runner.setCustomTmpDirPath(AnsibleUtil.getCustomTmpPathDir(contextBuilder.getFramework()));
     } catch (ConfigurationException e) {
           throw new FileCopierException("Error configuring Ansible.",AnsibleFailureReason.ParseArgumentsError, e);
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleModuleWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleModuleWorkflowStep.java
@@ -82,6 +82,7 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, AnsibleDescribable
 
         try {
             runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
+            runner.setCustomTmpDirPath(AnsibleUtil.getCustomTmpPathDir(contextBuilder.getFramework()));
         } catch (ConfigurationException e) {
             throw new StepException("Error configuring Ansible runner: " + e.getMessage(), e, AnsibleException.AnsibleFailureReason.ParseArgumentsError);
         }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleNodeExecutor.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleNodeExecutor.java
@@ -170,6 +170,7 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable, Pr
 
     try {
         runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
+        runner.setCustomTmpDirPath(AnsibleUtil.getCustomTmpPathDir(contextBuilder.getFramework()));
     } catch (ConfigurationException e) {
           return NodeExecutorResultImpl.createFailure(AnsibleException.AnsibleFailureReason.ParseArgumentsError, e.getMessage(), node);
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
@@ -93,6 +93,7 @@ public class AnsiblePlaybookInlineWorkflowNodeStep implements NodeStepPlugin, An
 
         try {
             runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
+            runner.setCustomTmpDirPath(AnsibleUtil.getCustomTmpPathDir(contextBuilder.getFramework()));
         } catch (ConfigurationException e) {
             throw new NodeStepException("Error configuring Ansible runner: "+e.getMessage(), AnsibleException.AnsibleFailureReason.ParseArgumentsError,e.getMessage());
         }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
@@ -95,6 +95,7 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
 
         try {
             runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
+            runner.setCustomTmpDirPath(AnsibleUtil.getCustomTmpPathDir(contextBuilder.getFramework()));
         } catch (ConfigurationException e) {
             throw new StepException("Error configuring Ansible runner: " + e.getMessage(), e, AnsibleException.AnsibleFailureReason.ParseArgumentsError);
         }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorflowNodeStep.java
@@ -91,6 +91,7 @@ public class AnsiblePlaybookWorflowNodeStep implements NodeStepPlugin, AnsibleDe
 
         try {
             runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
+            runner.setCustomTmpDirPath(AnsibleUtil.getCustomTmpPathDir(contextBuilder.getFramework()));
         } catch (ConfigurationException e) {
             throw new NodeStepException("Error configuring Ansible runner: "+e.getMessage(), AnsibleException.AnsibleFailureReason.ParseArgumentsError,e.getMessage());
         }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -94,6 +94,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
 
         try {
             runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
+            runner.setCustomTmpDirPath(AnsibleUtil.getCustomTmpPathDir(contextBuilder.getFramework()));
         } catch (ConfigurationException e) {
             throw new StepException("Error configuring Ansible runner: " + e.getMessage(), e, AnsibleException.AnsibleFailureReason.ParseArgumentsError);
         }

--- a/src/main/groovy/com/rundeck/plugins/ansible/util/AnsibleUtil.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/util/AnsibleUtil.java
@@ -124,7 +124,7 @@ public class AnsibleUtil {
 
     public static String getCustomTmpPathDir(Framework framework){
         String customTmpDir = framework.getPropertyLookup().getProperty("framework.tmp.dir");
-        if (customTmpDir.isEmpty()) {
+        if (customTmpDir == null ||  customTmpDir.isEmpty()) {
             customTmpDir = System.getProperty("java.io.tmpdir");
         }
         return  customTmpDir;

--- a/src/main/groovy/com/rundeck/plugins/ansible/util/AnsibleUtil.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/util/AnsibleUtil.java
@@ -1,9 +1,13 @@
 package com.rundeck.plugins.ansible.util;
 
+import com.dtolabs.rundeck.core.common.Framework;
 import com.dtolabs.rundeck.core.execution.ExecutionContext;
 import com.dtolabs.rundeck.core.execution.proxy.DefaultSecretBundle;
 import com.dtolabs.rundeck.core.execution.proxy.SecretBundle;
+import com.dtolabs.rundeck.core.execution.workflow.steps.PluginStepContextImpl;
 import com.dtolabs.rundeck.core.plugins.configuration.Property;
+import com.dtolabs.rundeck.core.utils.PropertyLookup;
+import com.dtolabs.rundeck.plugins.step.PluginStepContext;
 import com.rundeck.plugins.ansible.ansible.AnsibleDescribable;
 import com.rundeck.plugins.ansible.ansible.AnsibleRunnerContextBuilder;
 import com.rundeck.plugins.ansible.plugin.AnsibleNodeExecutor;
@@ -103,19 +107,27 @@ public class AnsibleUtil {
         return filterProperties;
     }
 
-
-    public static File createTemporaryFile(String suffix, String data) throws IOException {
-        File tempVarsFile = File.createTempFile("ansible-runner", suffix);
+    public static File createTemporaryFile(String prefix, String suffix, String data, String path) throws IOException {
+        if(prefix.isEmpty()){
+            prefix ="ansible-runner";
+        }
+        File tempVarsFile = File.createTempFile(prefix, suffix, new File(path));
         Files.write(tempVarsFile.toPath(), data.getBytes());
         return tempVarsFile;
     }
-
 
     public static String randomString(){
         byte[] bytes = new byte[32];
         new SecureRandom().nextBytes(bytes);
         return Base64.getEncoder().encodeToString(bytes);
+    }
 
+    public static String getCustomTmpPathDir(Framework framework){
+        String customTmpDir = framework.getPropertyLookup().getProperty("framework.tmp.dir");
+        if (customTmpDir.isEmpty()) {
+            customTmpDir = System.getProperty("java.io.tmpdir");
+        }
+        return  customTmpDir;
     }
 
 

--- a/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
@@ -45,6 +45,7 @@ class AnsibleRunnerSpec extends Specification{
 
         runner.processExecutorBuilder(processBuilder)
         runner.ansibleVault(ansibleVault)
+        runner.customTmpDirPath("/tmp")
 
         when:
         runner.build().run()
@@ -94,6 +95,7 @@ class AnsibleRunnerSpec extends Specification{
 
         runnerBuilder.processExecutorBuilder(processBuilder)
         runnerBuilder.ansibleVault(ansibleVault)
+        runnerBuilder.customTmpDirPath("/tmp")
 
         when:
         def result = runnerBuilder.build().run()
@@ -122,6 +124,7 @@ class AnsibleRunnerSpec extends Specification{
         runner.tempDirectory(Path.of(tmpDirectory.absolutePath))
         runner.sshPrivateKey(privateKey)
         runner.extraVars(extraVars)
+        runner.customTmpDirPath("/tmp")
 
         def process = Mock(Process){
             waitFor() >> 0
@@ -196,6 +199,7 @@ class AnsibleRunnerSpec extends Specification{
 
         when:
         AnsibleRunner runner = runnerBuilder.build()
+        runner.setCustomTmpDirPath("/tmp")
         runner.run()
 
         then:
@@ -245,6 +249,7 @@ class AnsibleRunnerSpec extends Specification{
 
         when:
         AnsibleRunner runner = runnerBuilder.build()
+        runner.setCustomTmpDirPath("/tmp")
         def result = runner.run()
 
         then:
@@ -293,6 +298,7 @@ class AnsibleRunnerSpec extends Specification{
 
         when:
         AnsibleRunner runner = runnerBuilder.build()
+        runner.setCustomTmpDirPath("/tmp")
         def result = runner.run()
 
         then:
@@ -342,6 +348,7 @@ class AnsibleRunnerSpec extends Specification{
 
         when:
         AnsibleRunner runner = runnerBuilder.build()
+        runner.setCustomTmpDirPath("/tmp")
         def result = runner.run()
 
         then:

--- a/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStepSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStepSpec.groovy
@@ -5,6 +5,7 @@ import com.dtolabs.rundeck.core.common.INodeEntry
 import com.dtolabs.rundeck.core.common.INodeSet
 import com.dtolabs.rundeck.core.execution.ExecutionContext
 import com.dtolabs.rundeck.core.execution.workflow.steps.node.NodeStepException
+import com.dtolabs.rundeck.core.utils.IPropertyLookup
 import com.dtolabs.rundeck.plugins.step.NodeStepPlugin
 import com.dtolabs.rundeck.plugins.step.PluginStepContext
 import org.junit.jupiter.api.Assertions
@@ -25,7 +26,11 @@ class AnsiblePlaybookInlineWorkflowNodeStepSpec extends Specification{
             getExecutionContext() >> Mock(ExecutionContext){
                 getDataContext() >> [:]
             }
-            getFramework() >> Mock(Framework)
+            getFramework() >> Mock(Framework){
+                getPropertyLookup() >> Mock(IPropertyLookup){
+                    getProperty("framework.tmp.dir") >> '/tmp'
+                }
+            }
             getNodes() >> Mock(INodeSet){
                 getNodes() >> []
             }

--- a/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceSpec.groovy
@@ -6,6 +6,7 @@ import com.dtolabs.rundeck.core.common.INodeSet
 import com.dtolabs.rundeck.core.resources.ResourceModelSource
 import com.dtolabs.rundeck.core.resources.ResourceModelSourceException
 import com.dtolabs.rundeck.core.storage.keys.KeyStorageTree
+import com.dtolabs.rundeck.core.utils.IPropertyLookup
 import com.rundeck.plugins.ansible.ansible.AnsibleDescribable
 import com.rundeck.plugins.ansible.ansible.AnsibleInventoryList
 import org.rundeck.app.spi.Services
@@ -30,6 +31,9 @@ class AnsibleResourceModelSourceSpec extends Specification {
         String usernameValue = 'test'
         String descValue = 'CentOS Linux'
         Framework framework = Mock(Framework) {
+            getPropertyLookup() >> Mock(IPropertyLookup){
+                getProperty("framework.tmp.dir") >> '/tmp'
+            }
             getBaseDir() >> Mock(File) {
                 getAbsolutePath() >> '/tmp'
             }
@@ -97,6 +101,9 @@ class AnsibleResourceModelSourceSpec extends Specification {
     void "ansible yaml data size parameter without an Exception"() {
         given:
         Framework framework = Mock(Framework) {
+            getPropertyLookup() >> Mock(IPropertyLookup){
+                getProperty("framework.tmp.dir") >> '/tmp'
+            }
             getBaseDir() >> Mock(File) {
                 getAbsolutePath() >> '/tmp'
             }

--- a/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/plugin/AnsibleResourceModelSourceSpec.groovy
@@ -140,6 +140,9 @@ class AnsibleResourceModelSourceSpec extends Specification {
             getBaseDir() >> Mock(File) {
                 getAbsolutePath() >> '/tmp'
             }
+            getPropertyLookup() >> Mock(IPropertyLookup){
+                getProperty("framework.tmp.dir") >> '/tmp'
+            }
         }
         ResourceModelSource plugin = new AnsibleResourceModelSource(framework)
         Properties config = new Properties()
@@ -166,6 +169,9 @@ class AnsibleResourceModelSourceSpec extends Specification {
         Framework framework = Mock(Framework) {
             getBaseDir() >> Mock(File) {
                 getAbsolutePath() >> '/tmp'
+            }
+            getPropertyLookup() >> Mock(IPropertyLookup){
+                getProperty("framework.tmp.dir") >> '/tmp'
             }
         }
         ResourceModelSource plugin = new AnsibleResourceModelSource(framework)

--- a/src/test/groovy/com/rundeck/plugins/ansible/util/AnsibleUtilSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/util/AnsibleUtilSpec.groovy
@@ -1,0 +1,63 @@
+package com.rundeck.plugins.ansible.util
+
+import com.dtolabs.rundeck.core.common.Framework
+import com.dtolabs.rundeck.core.utils.PropertyLookup
+import spock.lang.Specification
+import spock.lang.TempDir
+
+import java.nio.file.Files
+
+class AnsibleUtilSpec extends Specification{
+
+    @TempDir
+    File tempDir
+
+    def "createTemporaryFile should create a temporary file with the correct properties"() {
+        given: "Input parameters for the temporary file"
+        String prefix = inputPrefix
+        String suffix = ".txt"
+        String data = "test data"
+        String path = tempDir.absolutePath
+
+        when: "The method is called"
+        File result = AnsibleUtil.createTemporaryFile(prefix, suffix, data, path)
+
+        then: "The file is created in the specified path with the correct content"
+        result.exists()
+        result.parent == tempDir.absolutePath
+        result.name.startsWith(expectedPrefix)
+        result.name.endsWith(suffix)
+        new String(Files.readAllBytes(result.toPath())) == data
+
+        where:
+        inputPrefix        || expectedPrefix
+        "my-prefix"        || "my-prefix"
+        ""                 || "ansible-runner"
+    }
+
+    def "getCustomTmpPathDir should return the correct tmp path based on framework properties"() {
+        given: "A mock Framework and PropertyLookup"
+        def framework = Mock(Framework)
+        def propertyLookup = Mock(PropertyLookup)
+        framework.getPropertyLookup() >> propertyLookup
+
+        and: "A specific value for framework.tmp.dir property"
+        propertyLookup.getProperty("framework.tmp.dir") >> frameworkTmpDir
+
+        and: "A system property for java.io.tmpdir"
+        System.setProperty("java.io.tmpdir", systemTmpDir)
+
+        when: "The method is called"
+        def result = AnsibleUtil.getCustomTmpPathDir(framework)
+
+        then: "The expected tmp path is returned"
+        result == expectedTmpDir
+
+        where:
+        frameworkTmpDir       | systemTmpDir       || expectedTmpDir
+        "custom/tmp/dir"      | "/default/tmp"     || "custom/tmp/dir"   // Case where framework.tmp.dir is set
+        ""                    | "/default/tmp"     || "/default/tmp"     // Case where framework.tmp.dir is empty
+        null                  | "/default/tmp"     || "/default/tmp"     // Case where framework.tmp.dir is null
+    }
+}
+


### PR DESCRIPTION
## Before submitting this PR: 

- [x] Jira ticket is present in the title or in the description
- [x] All items marked FILL IN are filled
- [x] Any required labels are applied (Bug bash, exclude release notes, backport, etc.)
- [x] Testing/reviewer instructions are filled out

## About this change:

This update modifies the Ansible plugin and its sidecar to support the use of a custom temporary directory instead of the default /tmp directory. The sidecar now forwards the overridden tmp path from the runner to the framework, enabling the plugin to correctly generate and use temporary scripts in the specified location.

This change resolves an issue where Ansible commands failed when attempting to use a non-default temporary directory, ensuring compatibility with environments that restrict or do not support the default /tmp directory.

**Jira Ticket**:  https://pagerduty.atlassian.net/browse/RPL-69

**Changes on the Ansible plugin**:
 https://github.com/rundeck-plugins/ansible-plugin/pull/405

### Purpose of the Changes:
Allow Ansible plugin to use a custom tmp dir to generate

**Customer Impact:**

This resolves an issue preventing users from successfully running Ansible commands when a custom temporary directory is required. The enhancement ensures compatibility with environments where the /tmp directory is restricted or unsuitable.

**Release Notes:**


**Kind of Change**

- [x] Bug Fix
- [ ] Enhancement/New Feature/Behavior
- [ ] Maintenance
- [ ] Backport (Other sections can be skipped)
- [ ] Other... (FILL IN)

**Development Checklist**

- [x] Unit Tests added for modified/added code
- [] Documentation PR: <!-- FILL IN -->
- [x] Documentation Not needed

Specific Considerations:

- [ ] Feature Flag required (New behavior), name: <!-- FILL IN -->
  - [x] The new behavior is OFF by default (flag is false by default)
- [ ] API Functional Tests added (API Changes)
- [ ] API Version Increment needed (*implies Documentation needed*)

GUI Changes:

- [x] No GUI Changes, OR
- [ ] Selenium UI Tests added
</details>

## Testing:

- Create an Ansible playbook workflow node step
- Create a runner 
- Change the tmp dir in the Runner server to 444 (read only) or change the name of the tmp after the runner is up.
- Run the runner like this, to change the default tmp dir: 
 **java -Drunner.log.output=console -Drunner.rundeck.overrideTempDir=true -Drunner.dirs.tmp=/my/custom/tmp/ -Dorg.sqlite.tmpdir=/my/custom/tmp/  -jar runner.jar**

Run an ansible job and it should run creating tmp files on the defined path.

**Testing setup:**
Can be tested locally with a rundeck server and a runner running locally or on docker. 

**Acceptance Criteria:**
  - [ ] Users can modify tmp dir for Ansible.
  - [ ] Jobs should run when the default tmp is blocked and a custom tmp is configured.
  - [ ] Resource model should bring nodes info when the default tmp is blocked and a custom tmp is configured.
  - [ ] Ansible should use default tmp dir is not custom tmp is configured. 

**QA/Bug Bash Needed?**

  <!-- 
  NOTE:  Apply a github Label to indicate need for Bug Bash or QA:
  
  "bug-bash"
  "manual-qa"
  
  --> 

- [ ] manual-qa/bug-bash Label is applied, OR
  - [ ] Not needed

**Manual QA Notes:**

  <!-- FILL IN -->

**Reviewer Checklist**

Functionality (choose one):

- [ ] I built and tested locally and code behaves as expected: OR
  - [ ] I tested via via Docker image, OR
  - [ ] It was not necessary, reason: <!-- FILL IN -->

Code:

- [ ] Meets quality and style guidelines
  - [ ] Has complete Unit tests
  - [ ] Has complete Functional Tests
</details>