### PR TITLE
RUN-4085 Generate Inventory with SSH password authentication

### DIFF
--- a/functional-test/README.md
+++ b/functional-test/README.md
@@ -173,7 +173,7 @@ The multi-node authentication feature allows running Ansible playbooks across mu
 4. Ansible uses host-specific credentials from group_vars
 
 **Requirements:**
-- Must use Ansible Playbook **Workflow Steps** (not Node Steps)
+- Must use Ansible Playbook **Workflow Steps** (not Node Steps); the multi-node authentication logic and inventory generation are only implemented for the Workflow Step variant of the plugin and are not executed for Node Steps, so enabling `project.ansible-generate-inventory-nodes-auth` while using Node Steps will not apply per-node credentials. This limitation exists because Node Steps run independently on each target node and do not share the global inventory context that the multi-node authentication feature relies on.
 - Node attributes must include `ansible-ssh-password-storage-path` for each node
 - Passwords are automatically encrypted using Ansible Vault
 - Supports special characters with proper YAML escaping

--- a/functional-test/README.md
+++ b/functional-test/README.md
@@ -1,0 +1,181 @@
+# Functional Tests for Ansible Plugin
+
+This directory contains functional tests for the Rundeck Ansible plugin using Testcontainers and Docker.
+
+## Prerequisites
+
+- Docker (Docker Desktop or Rancher Desktop)
+- Java 11 or later
+- Gradle 7.2 or later
+
+## Docker Configuration
+
+The functional tests use Testcontainers to spin up Docker containers for Rundeck and SSH nodes. Depending on your Docker setup, you may need to configure the Docker socket path.
+
+### Option 1: Using ~/.testcontainers.properties (Recommended)
+
+Create a file at `~/.testcontainers.properties` with the following content:
+
+**For Rancher Desktop on macOS:**
+```properties
+docker.host=unix:///Users/<your-username>/.rd/docker.sock
+```
+
+**For Docker Desktop on macOS/Linux:**
+```properties
+docker.host=unix:///var/run/docker.sock
+```
+
+**For Windows with Docker Desktop:**
+```properties
+docker.host=tcp://localhost:2375
+```
+
+### Option 2: Modify build.gradle
+
+Edit `functional-test/build.gradle` and update the `docker.host` paths on lines 52-53:
+
+```gradle
+systemProperty('docker.host', "unix:///path/to/your/docker.sock")
+environment 'DOCKER_HOST', 'unix:///path/to/your/docker.sock'
+```
+
+## Running the Tests
+
+### Run All Functional Tests
+
+```bash
+./gradlew :functional-test:functionalTest
+```
+
+### Run Specific Test Suite
+
+```bash
+# Multi-node authentication tests
+./gradlew :functional-test:functionalTest --tests "*MultiNodeAuthSpec*"
+
+# Basic integration tests
+./gradlew :functional-test:functionalTest --tests "*BasicIntegrationSpec*"
+
+# Plugin group tests
+./gradlew :functional-test:functionalTest --tests "*PluginGroupIntegrationSpec*"
+```
+
+## Test Suites
+
+### MultiNodeAuthSpec
+Tests the multi-node authentication feature where each node can have its own password stored in Rundeck's key storage.
+
+**Tests:**
+- `test ansible playbook with multi-node authentication` - Verifies Ansible playbooks execute across multiple nodes with per-node credentials
+- `test multi-node authentication with different passwords` - Tests script execution on multiple nodes with different passwords
+- `test nodes are accessible with different credentials` - Validates node registration and discovery
+- `test passwords with special characters are properly escaped` - Verifies YAML escaping for special characters in passwords
+
+**Test Environment:**
+- 3 SSH nodes (ssh-node, ssh-node-2, ssh-node-3)
+- Each node has a different password, including special characters
+- Tests both WorkflowStep (Ansible playbooks) and NodeStep (scripts) execution
+
+### BasicIntegrationSpec
+Basic integration tests for the Ansible plugin functionality.
+
+### PluginGroupIntegrationSpec
+Tests for plugin group configuration and execution.
+
+## Test Structure
+
+```
+functional-test/
+├── build.gradle                          # Test configuration
+├── README.md                             # This file
+└── src/
+    └── test/
+        ├── groovy/functional/            # Test specifications
+        │   ├── MultiNodeAuthSpec.groovy
+        │   ├── BasicIntegrationSpec.groovy
+        │   └── PluginGroupIntegrationSpec.groovy
+        └── resources/
+            ├── docker/                   # Docker compose and configs
+            │   ├── docker-compose.yml
+            │   ├── ansible-multi-node-auth/  # Multi-node test configs
+            │   ├── keys/                     # SSH keys for tests
+            │   ├── node/                     # SSH node Docker configs
+            │   └── rundeck/                  # Rundeck Docker configs
+            └── project-import/           # Rundeck project definitions
+                └── ansible-multi-node-auth/
+                    └── rundeck-ansible-multi-node-auth/
+                        ├── files/etc/project.properties
+                        └── jobs/*.xml
+```
+
+## Troubleshooting
+
+### Tests Fail with "Could not find Docker socket"
+
+**Problem:** Testcontainers cannot locate the Docker socket.
+
+**Solution:**
+1. Verify Docker is running: `docker ps`
+2. Check your Docker socket path:
+   - Rancher Desktop: `ls -la ~/.rd/docker.sock`
+   - Docker Desktop: `ls -la /var/run/docker.sock`
+3. Update `~/.testcontainers.properties` or `build.gradle` with the correct path
+
+### Tests Timeout or Hang
+
+**Problem:** Tests take too long or appear to hang.
+
+**Solution:**
+1. Check Docker container status: `docker ps -a`
+2. Check Docker logs: `docker logs <container-id>`
+3. Increase test timeout in build.gradle if needed
+4. Ensure sufficient Docker resources (memory/CPU)
+
+### Port Conflicts
+
+**Problem:** Tests fail with "port already in use" errors.
+
+**Solution:**
+1. Check for running containers: `docker ps`
+2. Stop conflicting containers: `docker stop <container-name>`
+3. Clean up: `docker-compose down` in the docker directory
+
+### Platform Mismatch Warnings (Apple Silicon)
+
+**Problem:** Warnings about platform mismatch (linux/amd64 vs linux/arm64).
+
+**Solution:** These warnings are expected on Apple Silicon Macs and can be safely ignored. Docker will use Rosetta 2 for emulation.
+
+## Test Reports
+
+After running tests, view the HTML report at:
+```
+functional-test/build/reports/tests/functionalTest/index.html
+```
+
+## Adding New Tests
+
+1. Create a new Spock specification in `src/test/groovy/functional/`
+2. Extend `BaseTestConfiguration` for common test utilities
+3. Add any required Docker configs to `src/test/resources/docker/`
+4. Add project imports to `src/test/resources/project-import/`
+5. Follow existing test patterns for consistency
+
+## Multi-Node Authentication Feature
+
+The multi-node authentication feature allows running Ansible playbooks across multiple nodes where each node has its own password stored in Rundeck's key storage.
+
+**How it works:**
+1. Enable at project level: `project.ansible-generate-inventory-nodes-auth=true`
+2. Store per-node passwords in Key Storage with paths specified in node attributes
+3. Plugin generates `group_vars/all.yaml` with vault-encrypted passwords
+4. Ansible uses host-specific credentials from group_vars
+
+**Requirements:**
+- Must use Ansible Playbook **Workflow Steps** (not Node Steps)
+- Node attributes must include `ansible-ssh-password-storage-path` for each node
+- Passwords are automatically encrypted using Ansible Vault
+- Supports special characters with proper YAML escaping
+
+See `MultiNodeAuthSpec.groovy` for comprehensive test examples.

--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -42,7 +42,14 @@ dependencies {
 
 tasks.register('functionalTest', Test) {
     useJUnitPlatform()
-    systemProperty('RUNDECK_TEST_IMAGE', "rundeck/rundeck:5.1.1")
+    systemProperty('RUNDECK_TEST_IMAGE', "rundeck/rundeck:5.18.0")
+
+    // Docker configuration for Testcontainers
+    // For Rancher Desktop on macOS: Use /Users/<username>/.rd/docker.sock
+    // For Docker Desktop on macOS: Use /var/run/docker.sock
+    // For Linux: Use /var/run/docker.sock
+    // You can also configure this via ~/.testcontainers.properties (see functional-test/README.md)
+
     description = "Run Ansible integration tests"
 }
 

--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -42,6 +42,13 @@ dependencies {
 
 tasks.register('functionalTest', Test) {
     useJUnitPlatform()
+
+    // Rundeck test image version
+    // NOTE: Using Rundeck 5.18.0 for functional testing. This version upgrade from the
+    // previously used 5.1.1 ensures compatibility with newer Rundeck releases and
+    // validates that the multi-node authentication feature works correctly with
+    // current Rundeck APIs and behavior. If the plugin's minimum supported Rundeck
+    // version changes, update both this test image and the plugin documentation.
     systemProperty('RUNDECK_TEST_IMAGE', "rundeck/rundeck:5.18.0")
 
     // Docker configuration for Testcontainers

--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
 tasks.register('functionalTest', Test) {
     useJUnitPlatform()
-    systemProperty('RUNDECK_TEST_IMAGE', "rundeck/rundeck:5.18.0")
+    systemProperty('RUNDECK_TEST_IMAGE', "rundeck/rundeck:5.1.1")
 
     // Docker configuration for Testcontainers
     // For Rancher Desktop on macOS: Use /Users/<username>/.rd/docker.sock

--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -44,12 +44,10 @@ tasks.register('functionalTest', Test) {
     useJUnitPlatform()
 
     // Rundeck test image version
-    // NOTE: Functional tests run against Rundeck 5.18.0. This is an upgrade from the
-    // previously used 5.1.1 to validate compatibility with newer Rundeck releases and
-    // ensure the multi-node authentication feature works correctly with current
-    // Rundeck APIs and behavior. The plugin's minimum supported Rundeck version is
-    // defined in the main README/changelog; updating that minimum version should be
-    // accompanied by updating this test image tag accordingly.
+    // Minimum supported Rundeck version for this plugin: 5.1.1 (see main README/changelog).
+    // Functional tests intentionally run against a newer version, Rundeck 5.18.0, to validate
+    // compatibility with current releases. When raising the minimum supported version, update
+    // this test image tag in tandem.
     systemProperty('RUNDECK_TEST_IMAGE', "rundeck/rundeck:5.18.0")
 
     // Docker configuration for Testcontainers

--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -44,11 +44,12 @@ tasks.register('functionalTest', Test) {
     useJUnitPlatform()
 
     // Rundeck test image version
-    // NOTE: Using Rundeck 5.18.0 for functional testing. This version upgrade from the
-    // previously used 5.1.1 ensures compatibility with newer Rundeck releases and
-    // validates that the multi-node authentication feature works correctly with
-    // current Rundeck APIs and behavior. If the plugin's minimum supported Rundeck
-    // version changes, update both this test image and the plugin documentation.
+    // NOTE: Functional tests run against Rundeck 5.18.0. This is an upgrade from the
+    // previously used 5.1.1 to validate compatibility with newer Rundeck releases and
+    // ensure the multi-node authentication feature works correctly with current
+    // Rundeck APIs and behavior. The plugin's minimum supported Rundeck version is
+    // defined in the main README/changelog; updating that minimum version should be
+    // accompanied by updating this test image tag accordingly.
     systemProperty('RUNDECK_TEST_IMAGE', "rundeck/rundeck:5.18.0")
 
     // Docker configuration for Testcontainers

--- a/functional-test/build.gradle
+++ b/functional-test/build.gradle
@@ -42,7 +42,7 @@ dependencies {
 
 tasks.register('functionalTest', Test) {
     useJUnitPlatform()
-    systemProperty('RUNDECK_TEST_IMAGE', "rundeck/rundeck:5.1.1")
+    systemProperty('RUNDECK_TEST_IMAGE', "rundeck/rundeck:5.18.0")
 
     // Docker configuration for Testcontainers
     // For Rancher Desktop on macOS: Use /Users/<username>/.rd/docker.sock

--- a/functional-test/src/test/groovy/functional/MultiNodeAuthSpec.groovy
+++ b/functional-test/src/test/groovy/functional/MultiNodeAuthSpec.groovy
@@ -12,11 +12,15 @@ class MultiNodeAuthSpec extends BaseTestConfiguration {
     static String NODE1_NAME = "ssh-node"
     static String NODE2_NAME = "ssh-node-2"
     static String NODE3_NAME = "ssh-node-3"
+    static String NODE4_NAME = "ssh-node-4"
 
     // Test passwords for each node (matching docker-compose.yml)
     static String NODE1_PASSWORD = "testpassword123"
     static String NODE2_PASSWORD = "password2_special!@#"
     static String NODE3_PASSWORD = 'password3"quote\'test'
+
+    // Private key for node 4
+    static String NODE4_PRIVATE_KEY_PATH = "src/test/resources/docker/keys/id_rsa"
 
     def setupSpec() {
         startCompose()
@@ -25,29 +29,12 @@ class MultiNodeAuthSpec extends BaseTestConfiguration {
 
     def configureMultiNodeAuthProject() {
         // Store passwords for each node in Rundeck key storage
-        okhttp3.RequestBody requestBody = okhttp3.RequestBody.create(
-            NODE1_PASSWORD.getBytes(),
-            org.rundeck.client.util.Client.MEDIA_TYPE_X_RUNDECK_PASSWORD
-        )
-        client.apiCall { api ->
-            api.createKeyStorage("project/$PROJ_NAME/ssh-node.pass", requestBody)
-        }
+        storePasswordInKeyStorage("ssh-node.pass", NODE1_PASSWORD)
+        storePasswordInKeyStorage("ssh-node-2.pass", NODE2_PASSWORD)
+        storePasswordInKeyStorage("ssh-node-3.pass", NODE3_PASSWORD)
 
-        requestBody = okhttp3.RequestBody.create(
-            NODE2_PASSWORD.getBytes(),
-            org.rundeck.client.util.Client.MEDIA_TYPE_X_RUNDECK_PASSWORD
-        )
-        client.apiCall { api ->
-            api.createKeyStorage("project/$PROJ_NAME/ssh-node-2.pass", requestBody)
-        }
-
-        requestBody = okhttp3.RequestBody.create(
-            NODE3_PASSWORD.getBytes(),
-            org.rundeck.client.util.Client.MEDIA_TYPE_X_RUNDECK_PASSWORD
-        )
-        client.apiCall { api ->
-            api.createKeyStorage("project/$PROJ_NAME/ssh-node-3.pass", requestBody)
-        }
+        // Store private key for node 4 in Rundeck key storage
+        storePrivateKeyInKeyStorage("ssh-node-4.key", NODE4_PRIVATE_KEY_PATH)
 
         // Create project
         def projList = client.apiCall { api -> api.listProjects() }
@@ -80,54 +67,82 @@ class MultiNodeAuthSpec extends BaseTestConfiguration {
         waitForNodeAvailability(PROJ_NAME, NODE1_NAME)
         waitForNodeAvailability(PROJ_NAME, NODE2_NAME)
         waitForNodeAvailability(PROJ_NAME, NODE3_NAME)
+        waitForNodeAvailability(PROJ_NAME, NODE4_NAME)
+    }
+
+    // Helper method to store password in Rundeck key storage
+    private void storePasswordInKeyStorage(String keyPath, String password) {
+        okhttp3.RequestBody requestBody = okhttp3.RequestBody.create(
+            password.getBytes(),
+            org.rundeck.client.util.Client.MEDIA_TYPE_X_RUNDECK_PASSWORD
+        )
+        client.apiCall { api ->
+            api.createKeyStorage("project/$PROJ_NAME/$keyPath", requestBody)
+        }
+    }
+
+    // Helper method to store private key in Rundeck key storage
+    private void storePrivateKeyInKeyStorage(String keyPath, String privateKeyFilePath) {
+        File privateKeyFile = new File(privateKeyFilePath)
+        okhttp3.RequestBody requestBody = okhttp3.RequestBody.create(
+            privateKeyFile,
+            org.rundeck.client.util.Client.MEDIA_TYPE_OCTET_STREAM
+        )
+        client.apiCall { api ->
+            api.createKeyStorage("project/$PROJ_NAME/$keyPath", requestBody)
+        }
+    }
+
+    // Helper method to execute job and get execution state
+    private Map executeJobAndWait(String jobId, String loglevel = 'INFO', String filter = null) {
+        JobRun request = new JobRun()
+        request.loglevel = loglevel
+        if (filter) {
+            request.filter = filter
+        }
+
+        def result = client.apiCall { api -> api.runJob(jobId, request) }
+        def executionId = result.id
+        def executionState = waitForJob(executionId)
+        def logs = getLogs(executionId)
+
+        return [executionState: executionState, logs: logs, executionId: executionId]
+    }
+
+    // Helper method to verify all four nodes are targeted
+    private void verifyAllNodesTargeted(def targetNodes) {
+        assert targetNodes.contains("ssh-node")
+        assert targetNodes.contains("ssh-node-2")
+        assert targetNodes.contains("ssh-node-3")
+        assert targetNodes.contains("ssh-node-4")
     }
 
     def "test multi-node authentication with different passwords"() {
         when:
         def jobId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"  // multi-node-ping-test job
-
-        JobRun request = new JobRun()
-        request.loglevel = 'INFO'
-
-        def result = client.apiCall { api -> api.runJob(jobId, request) }
-        def executionId = result.id
-
-        def executionState = waitForJob(executionId)
-        def logs = getLogs(executionId)
+        def result = executeJobAndWait(jobId, 'INFO')
 
         then:
-        // Job succeeded - this verifies that multi-node authentication worked
-        executionState != null
-        executionState.getExecutionState() == "SUCCEEDED"
+        // Job succeeded - this verifies that multi-node authentication worked (passwords + private keys)
+        result.executionState != null
+        result.executionState.getExecutionState() == "SUCCEEDED"
 
-        // Verify all three nodes were in the execution context
-        executionState.targetNodes.contains("ssh-node")
-        executionState.targetNodes.contains("ssh-node-2")
-        executionState.targetNodes.contains("ssh-node-3")
+        // Verify all four nodes were in the execution context (3 with passwords, 1 with private key)
+        verifyAllNodesTargeted(result.executionState.targetNodes)
     }
 
     def "test ansible playbook with multi-node authentication"() {
         when:
         def jobId = "b2c3d4e5-f6a7-8901-bcde-f12345678901"  // ansible-playbook-multi-node-test job
-
-        JobRun request = new JobRun()
-        request.loglevel = 'DEBUG'
-
-        def result = client.apiCall { api -> api.runJob(jobId, request) }
-        def executionId = result.id
-
-        def executionState = waitForJob(executionId)
-        def logs = getLogs(executionId)
+        def result = executeJobAndWait(jobId, 'DEBUG')
 
         then:
-        // Job succeeded - this verifies the playbook ran successfully with multi-node authentication
-        executionState != null
-        executionState.getExecutionState() == "SUCCEEDED"
+        // Job succeeded - this verifies the playbook ran successfully with multi-node authentication (mixed auth types)
+        result.executionState != null
+        result.executionState.getExecutionState() == "SUCCEEDED"
 
-        // Verify all three nodes were targeted by the playbook execution
-        executionState.targetNodes.contains("ssh-node")
-        executionState.targetNodes.contains("ssh-node-2")
-        executionState.targetNodes.contains("ssh-node-3")
+        // Verify all four nodes were targeted by the playbook execution (3 passwords + 1 private key)
+        verifyAllNodesTargeted(result.executionState.targetNodes)
     }
 
     def "test nodes are accessible with different credentials"() {
@@ -136,38 +151,48 @@ class MultiNodeAuthSpec extends BaseTestConfiguration {
         def nodes = client.apiCall { api -> api.listNodes(PROJ_NAME, ".*") }
 
         then:
-        // Verify all three nodes are registered
+        // Verify all four nodes are registered (3 with password auth, 1 with private key auth)
         nodes != null
-        nodes.size() >= 3
+        nodes.size() >= 4
         nodes.get(NODE1_NAME) != null
         nodes.get(NODE2_NAME) != null
         nodes.get(NODE3_NAME) != null
+        nodes.get(NODE4_NAME) != null
     }
 
     def "test passwords with special characters are properly escaped"() {
         when:
         def jobId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-
-        JobRun request = new JobRun()
-        request.loglevel = 'DEBUG'
-        request.filter = "name: ssh-node-2 || name: ssh-node-3"  // Only test nodes with special chars in passwords
-
-        def result = client.apiCall { api -> api.runJob(jobId, request) }
-        def executionId = result.id
-
-        def executionState = waitForJob(executionId)
-        def logs = getLogs(executionId)
+        def result = executeJobAndWait(jobId, 'DEBUG', "name: ssh-node-2 || name: ssh-node-3")
 
         then:
         // Job succeeded even with special characters in passwords - verifies password escaping works
-        executionState != null
-        executionState.getExecutionState() == "SUCCEEDED"
+        result.executionState != null
+        result.executionState.getExecutionState() == "SUCCEEDED"
 
         // Verify nodes with special character passwords were targeted
-        executionState.targetNodes.contains("ssh-node-2")
-        executionState.targetNodes.contains("ssh-node-3")
+        result.executionState.targetNodes.contains("ssh-node-2")
+        result.executionState.targetNodes.contains("ssh-node-3")
 
         // No YAML parsing errors - verifies special characters were properly escaped
-        !logs.any { it.log.toLowerCase().contains("yaml") && it.log.toLowerCase().contains("error") }
+        !result.logs.any { it.log.toLowerCase().contains("yaml") && it.log.toLowerCase().contains("error") }
+    }
+
+    def "test private key authentication works in isolation"() {
+        when:
+        def jobId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"  // multi-node-ping-test job
+        def result = executeJobAndWait(jobId, 'DEBUG', "name: ssh-node-4")
+
+        then:
+        // Job succeeded with ONLY private key authentication (no passwords)
+        result.executionState != null
+        result.executionState.getExecutionState() == "SUCCEEDED"
+
+        // Verify only the private key node was targeted
+        result.executionState.targetNodes.contains("ssh-node-4")
+        result.executionState.targetNodes.size() == 1
+
+        // Verify no password-related errors in logs
+        !result.logs.any { it.log.toLowerCase().contains("password") && it.log.toLowerCase().contains("error") }
     }
 }

--- a/functional-test/src/test/groovy/functional/MultiNodeAuthSpec.groovy
+++ b/functional-test/src/test/groovy/functional/MultiNodeAuthSpec.groovy
@@ -1,0 +1,173 @@
+package functional
+
+import functional.base.BaseTestConfiguration
+import functional.util.TestUtil
+import org.rundeck.client.api.model.JobRun
+import org.testcontainers.spock.Testcontainers
+
+@Testcontainers
+class MultiNodeAuthSpec extends BaseTestConfiguration {
+
+    static String PROJ_NAME = 'ansible-multi-node-auth'
+    static String NODE1_NAME = "ssh-node"
+    static String NODE2_NAME = "ssh-node-2"
+    static String NODE3_NAME = "ssh-node-3"
+
+    // Test passwords for each node (matching docker-compose.yml)
+    static String NODE1_PASSWORD = "testpassword123"
+    static String NODE2_PASSWORD = "password2_special!@#"
+    static String NODE3_PASSWORD = 'password3"quote\'test'
+
+    def setupSpec() {
+        startCompose()
+        configureMultiNodeAuthProject()
+    }
+
+    def configureMultiNodeAuthProject() {
+        // Store passwords for each node in Rundeck key storage
+        okhttp3.RequestBody requestBody = okhttp3.RequestBody.create(
+            NODE1_PASSWORD.getBytes(),
+            org.rundeck.client.util.Client.MEDIA_TYPE_X_RUNDECK_PASSWORD
+        )
+        client.apiCall { api ->
+            api.createKeyStorage("project/$PROJ_NAME/ssh-node.pass", requestBody)
+        }
+
+        requestBody = okhttp3.RequestBody.create(
+            NODE2_PASSWORD.getBytes(),
+            org.rundeck.client.util.Client.MEDIA_TYPE_X_RUNDECK_PASSWORD
+        )
+        client.apiCall { api ->
+            api.createKeyStorage("project/$PROJ_NAME/ssh-node-2.pass", requestBody)
+        }
+
+        requestBody = okhttp3.RequestBody.create(
+            NODE3_PASSWORD.getBytes(),
+            org.rundeck.client.util.Client.MEDIA_TYPE_X_RUNDECK_PASSWORD
+        )
+        client.apiCall { api ->
+            api.createKeyStorage("project/$PROJ_NAME/ssh-node-3.pass", requestBody)
+        }
+
+        // Create project
+        def projList = client.apiCall { api -> api.listProjects() }
+        if (!projList*.name.contains(PROJ_NAME)) {
+            client.apiCall { api ->
+                api.createProject(new org.rundeck.client.api.model.ProjectItem(name: PROJ_NAME))
+            }
+        }
+
+        // Import project configuration
+        File projectFile = TestUtil.createArchiveJarFile(
+            PROJ_NAME,
+            new File("src/test/resources/project-import/$PROJ_NAME")
+        )
+        okhttp3.RequestBody body = okhttp3.RequestBody.create(
+            projectFile,
+            org.rundeck.client.util.Client.MEDIA_TYPE_ZIP
+        )
+        client.apiCall { api ->
+            api.importProjectArchive(
+                PROJ_NAME,
+                "preserve",
+                true, true, true, true, true, true, true,
+                [:],
+                body
+            )
+        }
+
+        // Wait for nodes to be available
+        waitForNodeAvailability(PROJ_NAME, NODE1_NAME)
+        waitForNodeAvailability(PROJ_NAME, NODE2_NAME)
+        waitForNodeAvailability(PROJ_NAME, NODE3_NAME)
+    }
+
+    def "test multi-node authentication with different passwords"() {
+        when:
+        def jobId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"  // multi-node-ping-test job
+
+        JobRun request = new JobRun()
+        request.loglevel = 'INFO'
+
+        def result = client.apiCall { api -> api.runJob(jobId, request) }
+        def executionId = result.id
+
+        def executionState = waitForJob(executionId)
+        def logs = getLogs(executionId)
+
+        then:
+        // Job succeeded - this verifies that multi-node authentication worked
+        executionState != null
+        executionState.getExecutionState() == "SUCCEEDED"
+
+        // Verify all three nodes were in the execution context
+        executionState.targetNodes.contains("ssh-node")
+        executionState.targetNodes.contains("ssh-node-2")
+        executionState.targetNodes.contains("ssh-node-3")
+    }
+
+    def "test ansible playbook with multi-node authentication"() {
+        when:
+        def jobId = "b2c3d4e5-f6a7-8901-bcde-f12345678901"  // ansible-playbook-multi-node-test job
+
+        JobRun request = new JobRun()
+        request.loglevel = 'DEBUG'
+
+        def result = client.apiCall { api -> api.runJob(jobId, request) }
+        def executionId = result.id
+
+        def executionState = waitForJob(executionId)
+        def logs = getLogs(executionId)
+
+        then:
+        // Job succeeded - this verifies the playbook ran successfully with multi-node authentication
+        executionState != null
+        executionState.getExecutionState() == "SUCCEEDED"
+
+        // Verify all three nodes were targeted by the playbook execution
+        executionState.targetNodes.contains("ssh-node")
+        executionState.targetNodes.contains("ssh-node-2")
+        executionState.targetNodes.contains("ssh-node-3")
+    }
+
+    def "test nodes are accessible with different credentials"() {
+        when:
+        // List all nodes in the project
+        def nodes = client.apiCall { api -> api.listNodes(PROJ_NAME, ".*") }
+
+        then:
+        // Verify all three nodes are registered
+        nodes != null
+        nodes.size() >= 3
+        nodes.get(NODE1_NAME) != null
+        nodes.get(NODE2_NAME) != null
+        nodes.get(NODE3_NAME) != null
+    }
+
+    def "test passwords with special characters are properly escaped"() {
+        when:
+        def jobId = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+
+        JobRun request = new JobRun()
+        request.loglevel = 'DEBUG'
+        request.filter = "name: ssh-node-2 || name: ssh-node-3"  // Only test nodes with special chars in passwords
+
+        def result = client.apiCall { api -> api.runJob(jobId, request) }
+        def executionId = result.id
+
+        def executionState = waitForJob(executionId)
+        def logs = getLogs(executionId)
+
+        then:
+        // Job succeeded even with special characters in passwords - verifies password escaping works
+        executionState != null
+        executionState.getExecutionState() == "SUCCEEDED"
+
+        // Verify nodes with special character passwords were targeted
+        executionState.targetNodes.contains("ssh-node-2")
+        executionState.targetNodes.contains("ssh-node-3")
+
+        // No YAML parsing errors - verifies special characters were properly escaped
+        !logs.any { it.log.toLowerCase().contains("yaml") && it.log.toLowerCase().contains("error") }
+    }
+}

--- a/functional-test/src/test/groovy/functional/MultiNodeAuthSpec.groovy
+++ b/functional-test/src/test/groovy/functional/MultiNodeAuthSpec.groovy
@@ -17,7 +17,7 @@ class MultiNodeAuthSpec extends BaseTestConfiguration {
     // Test passwords for each node (matching docker-compose.yml)
     static String NODE1_PASSWORD = "testpassword123"
     static String NODE2_PASSWORD = "password2_special!@#"
-    static String NODE3_PASSWORD = 'password3"quote\'test'
+    static String NODE3_PASSWORD = 'password3"quote\'test' // Expected password value: password3"quote'test
 
     // Private key for node 4
     static String NODE4_PRIVATE_KEY_PATH = "src/test/resources/docker/keys/id_rsa"

--- a/functional-test/src/test/resources/docker/ansible-multi-node-auth/README.md
+++ b/functional-test/src/test/resources/docker/ansible-multi-node-auth/README.md
@@ -7,7 +7,7 @@ This test verifies the multi-node authentication feature where each node can hav
 ### Nodes
 - **ssh-node**: Standard password (`testpassword123`)
 - **ssh-node-2**: Password with special characters (`password2_special!@#`)
-- **ssh-node-3**: Password with quotes (`password3"quote'test`)
+- **ssh-node-3**: Password containing both a double quote (") and a single quote ('): password3"quote'test
 - **ssh-node-4**: Private key authentication (uses SSH key from key storage)
 
 ### Files

--- a/functional-test/src/test/resources/docker/ansible-multi-node-auth/README.md
+++ b/functional-test/src/test/resources/docker/ansible-multi-node-auth/README.md
@@ -1,0 +1,57 @@
+# Multi-Node Authentication Functional Test
+
+This test verifies the multi-node authentication feature where each node can have its own password stored in Rundeck's key storage.
+
+## Test Setup
+
+### Nodes
+- **ssh-node**: Standard password (`testpassword123`)
+- **ssh-node-2**: Password with special characters (`password2_special!@#`)
+- **ssh-node-3**: Password with quotes (`password3"quote'test`)
+
+### Files
+- `resources.xml`: Defines three nodes with node-specific password storage paths
+- `inventory.ini`: Ansible inventory file for the test nodes
+- `ansible.cfg`: Ansible configuration
+- `test-playbook.yml`: Test playbook for verification
+
+## What's Being Tested
+
+1. **Multi-node authentication with different passwords per node**
+   - Each node has a different password stored in Rundeck key storage
+   - The plugin generates `group_vars/all.yaml` with vault-encrypted passwords
+   - Each node authenticates with its specific credentials
+
+2. **Password escaping for special characters**
+   - Node 2 has special characters: `!`, `@`, `#`
+   - Node 3 has quotes: `"` and `'`
+   - Tests verify YAML escaping works correctly
+
+3. **Project-level configuration**
+   - `project.ansible-generate-inventory-nodes-auth=true` enables the feature
+   - Configuration is at project level, not workflow step level
+
+## Jobs
+
+- **multi-node-ping-test**: Simple script that runs on all nodes
+- **ansible-playbook-multi-node-test**: Ansible playbook that verifies authentication on each node
+
+## Expected Behavior
+
+1. Plugin reads node attributes to get password storage paths for each node
+2. Plugin retrieves passwords from Rundeck key storage
+3. Plugin escapes passwords to prevent YAML parsing errors
+4. Plugin encrypts passwords using Ansible Vault
+5. Plugin generates `group_vars/all.yaml` with:
+   ```yaml
+   host_passwords:
+     ssh-node: !vault | ...
+     ssh-node-2: !vault | ...
+     ssh-node-3: !vault | ...
+   host_users:
+     ssh-node: rundeck
+     ssh-node-2: rundeck
+     ssh-node-3: rundeck
+   ```
+6. Ansible uses host-specific credentials from group_vars
+7. Each node authenticates successfully with its own password

--- a/functional-test/src/test/resources/docker/ansible-multi-node-auth/README.md
+++ b/functional-test/src/test/resources/docker/ansible-multi-node-auth/README.md
@@ -1,6 +1,6 @@
 # Multi-Node Authentication Functional Test
 
-This test verifies the multi-node authentication feature where each node can have its own password stored in Rundeck's key storage.
+This test verifies the multi-node authentication feature where each node can have its own credentials (password or private key) stored in Rundeck's key storage.
 
 ## Test Setup
 
@@ -8,18 +8,20 @@ This test verifies the multi-node authentication feature where each node can hav
 - **ssh-node**: Standard password (`testpassword123`)
 - **ssh-node-2**: Password with special characters (`password2_special!@#`)
 - **ssh-node-3**: Password with quotes (`password3"quote'test`)
+- **ssh-node-4**: Private key authentication (uses SSH key from key storage)
 
 ### Files
-- `resources.xml`: Defines three nodes with node-specific password storage paths
+- `resources.xml`: Defines four nodes with node-specific authentication (three with password storage paths, one with private key storage path)
 - `inventory.ini`: Ansible inventory file for the test nodes
 - `ansible.cfg`: Ansible configuration
 - `test-playbook.yml`: Test playbook for verification
 
 ## What's Being Tested
 
-1. **Multi-node authentication with different passwords per node**
-   - Each node has a different password stored in Rundeck key storage
-   - The plugin generates `group_vars/all.yaml` with vault-encrypted passwords
+1. **Multi-node authentication with different credentials per node**
+   - Three nodes have different passwords stored in Rundeck key storage
+   - One node uses private key authentication stored in Rundeck key storage
+   - The plugin generates `group_vars/all.yaml` with vault-encrypted passwords and private key paths
    - Each node authenticates with its specific credentials
 
 2. **Password escaping for special characters**
@@ -52,6 +54,9 @@ This test verifies the multi-node authentication feature where each node can hav
      ssh-node: rundeck
      ssh-node-2: rundeck
      ssh-node-3: rundeck
+     ssh-node-4: rundeck
+   host_private_keys:
+     ssh-node-4: /path/to/temporary/key
    ```
 6. Ansible uses host-specific credentials from group_vars
-7. Each node authenticates successfully with its own password
+7. Each node authenticates successfully with its own credentials (password or private key)

--- a/functional-test/src/test/resources/docker/ansible-multi-node-auth/ansible.cfg
+++ b/functional-test/src/test/resources/docker/ansible-multi-node-auth/ansible.cfg
@@ -1,0 +1,8 @@
+[defaults]
+host_key_checking = False
+timeout = 30
+gathering = smart
+fact_caching = jsonfile
+fact_caching_connection = /tmp/ansible_facts
+fact_caching_timeout = 3600
+stdout_callback = yaml

--- a/functional-test/src/test/resources/docker/ansible-multi-node-auth/inventory.ini
+++ b/functional-test/src/test/resources/docker/ansible-multi-node-auth/inventory.ini
@@ -1,0 +1,7 @@
+[test_nodes]
+ssh-node ansible_host=ssh-node ansible_port=22
+ssh-node-2 ansible_host=ssh-node-2 ansible_port=22
+ssh-node-3 ansible_host=ssh-node-3 ansible_port=22
+
+[test_nodes:vars]
+ansible_connection=ssh

--- a/functional-test/src/test/resources/docker/ansible-multi-node-auth/inventory.ini
+++ b/functional-test/src/test/resources/docker/ansible-multi-node-auth/inventory.ini
@@ -2,6 +2,7 @@
 ssh-node ansible_host=ssh-node ansible_port=22
 ssh-node-2 ansible_host=ssh-node-2 ansible_port=22
 ssh-node-3 ansible_host=ssh-node-3 ansible_port=22
+ssh-node-4 ansible_host=ssh-node-4 ansible_port=22
 
 [test_nodes:vars]
 ansible_connection=ssh

--- a/functional-test/src/test/resources/docker/ansible-multi-node-auth/resources.xml
+++ b/functional-test/src/test/resources/docker/ansible-multi-node-auth/resources.xml
@@ -38,4 +38,17 @@
         ansible-ssh-auth-type="password"
         ansible-ssh-password-storage-path="keys/project/ansible-multi-node-auth/ssh-node-3.pass"
         ansible-ssh-user="rundeck"/>
+
+  <node name="ssh-node-4"
+        description="Test node 4 with private key authentication"
+        tags="test,multi-node,privatekey"
+        hostname="ssh-node-4"
+        osArch="amd64"
+        osFamily="unix"
+        osName="Linux"
+        osVersion="5.0"
+        username="rundeck"
+        ansible-ssh-auth-type="privateKey"
+        ansible-ssh-key-storage-path="keys/project/ansible-multi-node-auth/ssh-node-4.key"
+        ansible-ssh-user="rundeck"/>
 </project>

--- a/functional-test/src/test/resources/docker/ansible-multi-node-auth/resources.xml
+++ b/functional-test/src/test/resources/docker/ansible-multi-node-auth/resources.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <node name="ssh-node"
+        description="Test node 1 with standard password"
+        tags="test,multi-node"
+        hostname="ssh-node"
+        osArch="amd64"
+        osFamily="unix"
+        osName="Linux"
+        osVersion="5.0"
+        username="rundeck"
+        ansible-ssh-auth-type="password"
+        ansible-ssh-password-storage-path="keys/project/ansible-multi-node-auth/ssh-node.pass"
+        ansible-ssh-user="rundeck"/>
+
+  <node name="ssh-node-2"
+        description="Test node 2 with special characters in password"
+        tags="test,multi-node,special-chars"
+        hostname="ssh-node-2"
+        osArch="amd64"
+        osFamily="unix"
+        osName="Linux"
+        osVersion="5.0"
+        username="rundeck"
+        ansible-ssh-auth-type="password"
+        ansible-ssh-password-storage-path="keys/project/ansible-multi-node-auth/ssh-node-2.pass"
+        ansible-ssh-user="rundeck"/>
+
+  <node name="ssh-node-3"
+        description="Test node 3 with quotes in password"
+        tags="test,multi-node,special-chars"
+        hostname="ssh-node-3"
+        osArch="amd64"
+        osFamily="unix"
+        osName="Linux"
+        osVersion="5.0"
+        username="rundeck"
+        ansible-ssh-auth-type="password"
+        ansible-ssh-password-storage-path="keys/project/ansible-multi-node-auth/ssh-node-3.pass"
+        ansible-ssh-user="rundeck"/>
+</project>

--- a/functional-test/src/test/resources/docker/ansible-multi-node-auth/test-playbook.yml
+++ b/functional-test/src/test/resources/docker/ansible-multi-node-auth/test-playbook.yml
@@ -1,0 +1,39 @@
+---
+- name: Multi-Node Authentication Test Playbook
+  hosts: all
+  gather_facts: yes
+  tasks:
+    - name: Ping all nodes
+      ping:
+
+    - name: Get hostname
+      command: hostname
+      register: node_hostname
+
+    - name: Display connection info
+      debug:
+        msg: "Successfully connected to {{ node_hostname.stdout }} as {{ ansible_user_id }}"
+
+    - name: Create test file
+      file:
+        path: "/tmp/multi_node_test_{{ inventory_hostname }}.txt"
+        state: touch
+        mode: '0644'
+
+    - name: Write test content
+      copy:
+        content: "Multi-node authentication test passed on {{ inventory_hostname }}\n"
+        dest: "/tmp/multi_node_test_{{ inventory_hostname }}.txt"
+
+    - name: Verify file exists
+      stat:
+        path: "/tmp/multi_node_test_{{ inventory_hostname }}.txt"
+      register: test_file_stat
+
+    - name: Assert test file was created
+      assert:
+        that:
+          - test_file_stat.stat.exists
+          - test_file_stat.stat.isreg
+        success_msg: "Test file created successfully on {{ inventory_hostname }}"
+        fail_msg: "Failed to create test file on {{ inventory_hostname }}"

--- a/functional-test/src/test/resources/docker/docker-compose.yml
+++ b/functional-test/src/test/resources/docker/docker-compose.yml
@@ -29,7 +29,7 @@ services:
     build:
       context: node
     environment:
-      NODE_USER_PASSWORD: password3"quote'test
+      NODE_USER_PASSWORD: 'password3"quote''test'
     networks:
       - rundeck
     ports:

--- a/functional-test/src/test/resources/docker/docker-compose.yml
+++ b/functional-test/src/test/resources/docker/docker-compose.yml
@@ -13,6 +13,30 @@ services:
     volumes:
       - ./keys:/configuration:rw
 
+  ssh-node-2:
+    build:
+      context: node
+    environment:
+      NODE_USER_PASSWORD: password2_special!@#
+    networks:
+      - rundeck
+    ports:
+      - "2223:22"
+    volumes:
+      - ./keys:/configuration:rw
+
+  ssh-node-3:
+    build:
+      context: node
+    environment:
+      NODE_USER_PASSWORD: password3"quote'test
+    networks:
+      - rundeck
+    ports:
+      - "2224:22"
+    volumes:
+      - ./keys:/configuration:rw
+
   rundeck:
     build:
       context: rundeck
@@ -37,6 +61,7 @@ services:
     - ./ansible-yaml-parsing:/home/rundeck/ansible-yaml-parsing:rw
     - ./ansible-child-groups:/home/rundeck/ansible-child-groups:rw
     - ./ansible-max-aliases:/home/rundeck/ansible-max-aliases:rw
+    - ./ansible-multi-node-auth:/home/rundeck/ansible-multi-node-auth:rw
 
 volumes:
   rundeck-data:

--- a/functional-test/src/test/resources/docker/docker-compose.yml
+++ b/functional-test/src/test/resources/docker/docker-compose.yml
@@ -37,6 +37,18 @@ services:
     volumes:
       - ./keys:/configuration:rw
 
+  ssh-node-4:
+    build:
+      context: node
+    environment:
+      NODE_USER_PASSWORD: unused_password
+    networks:
+      - rundeck
+    ports:
+      - "2225:22"
+    volumes:
+      - ./keys:/configuration:rw
+
   rundeck:
     build:
       context: rundeck

--- a/functional-test/src/test/resources/project-import/ansible-multi-node-auth/rundeck-ansible-multi-node-auth/files/acls/node-acl.aclpolicy
+++ b/functional-test/src/test/resources/project-import/ansible-multi-node-auth/rundeck-ansible-multi-node-auth/files/acls/node-acl.aclpolicy
@@ -1,0 +1,16 @@
+description: Node access for project
+context:
+  project: '.*'
+for:
+  resource:
+    - equals:
+        kind: node
+      allow: [read,create,update,refresh]
+  adhoc:
+    - allow: [read,run,runAs,kill,killAs]
+  job:
+    - allow: [create,read,update,delete,run,runAs,kill,killAs]
+  node:
+    - allow: [read,run]
+by:
+  username: admin

--- a/functional-test/src/test/resources/project-import/ansible-multi-node-auth/rundeck-ansible-multi-node-auth/files/etc/project.properties
+++ b/functional-test/src/test/resources/project-import/ansible-multi-node-auth/rundeck-ansible-multi-node-auth/files/etc/project.properties
@@ -1,0 +1,28 @@
+#Multi-Node Authentication Test Project
+project.name=ansible-multi-node-auth
+project.description=Test project for multi-node authentication with per-node credentials
+project.disable.executions=false
+project.disable.schedule=false
+project.execution.history.cleanup.enabled=false
+project.jobs.gui.groupExpandLevel=1
+project.nodeCache.enabled=true
+project.nodeCache.firstLoadSynch=true
+project.output.allowUnsanitized=false
+
+# Enable multi-node authentication at project level
+project.ansible-generate-inventory-nodes-auth=true
+
+# Ansible configuration
+project.ansible-config-file-path=/home/rundeck/ansible-multi-node-auth/ansible.cfg
+project.ansible-executable=/bin/bash
+
+# Resource source configuration - use file-based resources with node-specific attributes
+resources.source.1.config.file=/home/rundeck/ansible-multi-node-auth/resources.xml
+resources.source.1.config.generateFileAutomatically=false
+resources.source.1.config.includeServerNode=false
+resources.source.1.config.requireFileExists=true
+resources.source.1.type=file
+
+# Default node executor and file copier
+service.FileCopier.default.provider=com.batix.rundeck.plugins.AnsibleFileCopier
+service.NodeExecutor.default.provider=com.batix.rundeck.plugins.AnsibleNodeExecutor

--- a/functional-test/src/test/resources/project-import/ansible-multi-node-auth/rundeck-ansible-multi-node-auth/jobs/job-ansible-playbook-test.xml
+++ b/functional-test/src/test/resources/project-import/ansible-multi-node-auth/rundeck-ansible-multi-node-auth/jobs/job-ansible-playbook-test.xml
@@ -1,0 +1,35 @@
+<joblist>
+  <job>
+    <defaultTab>nodes</defaultTab>
+    <description>Test multi-node authentication using Ansible playbook</description>
+    <dispatch>
+      <excludePrecedence>true</excludePrecedence>
+      <keepgoing>false</keepgoing>
+      <rankOrder>ascending</rankOrder>
+      <successOnEmptyNodeFilter>false</successOnEmptyNodeFilter>
+      <threadcount>1</threadcount>
+    </dispatch>
+    <executionEnabled>true</executionEnabled>
+    <id>b2c3d4e5-f6a7-8901-bcde-f12345678901</id>
+    <loglevel>INFO</loglevel>
+    <name>ansible-playbook-multi-node-test</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <nodefilters>
+      <filter>.*</filter>
+    </nodefilters>
+    <nodesSelectedByDefault>true</nodesSelectedByDefault>
+    <plugins />
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='step-first'>
+      <command>
+        <step-plugin type='com.batix.rundeck.plugins.AnsiblePlaybookInlineWorkflowStep'>
+          <configuration>
+            <entry key='ansible-playbook-inline' value='- hosts: all&#10;  gather_facts: yes&#10;  tasks:&#10;    - name: Display hostname&#10;      debug:&#10;        msg: "Connected to {{ inventory_hostname }} successfully"&#10;&#10;    - name: Verify authentication&#10;      command: whoami&#10;      register: current_user&#10;&#10;    - name: Show current user&#10;      debug:&#10;        msg: "Authenticated as {{ current_user.stdout }}"&#10;&#10;    - name: Test file creation&#10;      file:&#10;        path: /tmp/multi_node_auth_test_{{ inventory_hostname }}&#10;        state: touch&#10;        mode: "0644"&#10;&#10;    - name: Verify file was created&#10;      stat:&#10;        path: /tmp/multi_node_auth_test_{{ inventory_hostname }}&#10;      register: test_file&#10;&#10;    - name: Assert file exists&#10;      assert:&#10;        that:&#10;          - test_file.stat.exists&#10;        success_msg: "Multi-node authentication test passed for {{ inventory_hostname }}"&#10;        fail_msg: "Multi-node authentication test failed for {{ inventory_hostname }}"' />
+            <entry key='ansible-inventory' value='/home/rundeck/ansible-multi-node-auth/inventory.ini' />
+          </configuration>
+        </step-plugin>
+      </command>
+    </sequence>
+    <uuid>b2c3d4e5-f6a7-8901-bcde-f12345678901</uuid>
+  </job>
+</joblist>

--- a/functional-test/src/test/resources/project-import/ansible-multi-node-auth/rundeck-ansible-multi-node-auth/jobs/job-multi-node-ping.xml
+++ b/functional-test/src/test/resources/project-import/ansible-multi-node-auth/rundeck-ansible-multi-node-auth/jobs/job-multi-node-ping.xml
@@ -1,0 +1,36 @@
+<joblist>
+  <job>
+    <defaultTab>nodes</defaultTab>
+    <description>Test multi-node authentication with different passwords</description>
+    <dispatch>
+      <excludePrecedence>true</excludePrecedence>
+      <keepgoing>true</keepgoing>
+      <rankOrder>ascending</rankOrder>
+      <successOnEmptyNodeFilter>false</successOnEmptyNodeFilter>
+      <threadcount>3</threadcount>
+    </dispatch>
+    <executionEnabled>true</executionEnabled>
+    <id>a1b2c3d4-e5f6-7890-abcd-ef1234567890</id>
+    <loglevel>INFO</loglevel>
+    <name>multi-node-ping-test</name>
+    <nodeFilterEditable>false</nodeFilterEditable>
+    <nodefilters>
+      <filter>name: ssh-node.*</filter>
+    </nodefilters>
+    <nodesSelectedByDefault>true</nodesSelectedByDefault>
+    <plugins />
+    <scheduleEnabled>true</scheduleEnabled>
+    <sequence keepgoing='false' strategy='node-first'>
+      <command>
+        <script><![CDATA[#!/bin/bash
+echo "Testing node: $(hostname)"
+echo "Current user: $(whoami)"
+echo "Node authenticated successfully!"
+pwd
+]]></script>
+        <scriptargs />
+      </command>
+    </sequence>
+    <uuid>a1b2c3d4-e5f6-7890-abcd-ef1234567890</uuid>
+  </job>
+</joblist>

--- a/functional-test/src/test/resources/project-import/ansible-multi-node-auth/rundeck-ansible-multi-node-auth/jobs/job-multi-node-ping.xml
+++ b/functional-test/src/test/resources/project-import/ansible-multi-node-auth/rundeck-ansible-multi-node-auth/jobs/job-multi-node-ping.xml
@@ -10,6 +10,7 @@
       <threadcount>3</threadcount>
     </dispatch>
     <executionEnabled>true</executionEnabled>
+    <!-- NOTE: This job ID/UUID is intentionally hardcoded and is referenced by MultiNodeAuthSpec.groovy (line 122). Do not change without updating the tests. -->
     <id>a1b2c3d4-e5f6-7890-abcd-ef1234567890</id>
     <loglevel>INFO</loglevel>
     <name>multi-node-ping-test</name>

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -100,6 +100,12 @@ public interface AnsibleDescribable extends Describable {
     public static final String ANSIBLE_INVENTORY_INLINE = "ansible-inventory-inline";
     public static final String ANSIBLE_INVENTORY = "ansible-inventory";
     public static final String ANSIBLE_GENERATE_INVENTORY = "ansible-generate-inventory";
+    /**
+     * Controls whether node authentication data is included when generating the inventory.
+     * This is an enhancement of {@link #ANSIBLE_GENERATE_INVENTORY} and only has effect
+     * when inventory generation is enabled. It is exposed as a separate top-level
+     * property for configuration/UI clarity.
+     */
     public static final String ANSIBLE_GENERATE_INVENTORY_NODES_AUTH = "ansible-generate-inventory-nodes-auth";
     public static final String ANSIBLE_MODULE = "ansible-module";
     public static final String ANSIBLE_MODULE_ARGS = "ansible-module-args";

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -237,8 +237,8 @@ public interface AnsibleDescribable extends Describable {
     static final Property GENERATE_INVENTORY_NODES_AUTH = PropertyBuilder.builder()
             .booleanType(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH)
             .required(false)
-            .title("Workflow Step: Generate inventory, pass node authentication from rundeck nodes")
-            .description("Pass authentication from rundeck nodes. Only applies to workflow steps.")
+            .title("Workflow Step: Generate Inventory and Pass Node Authentication from Rundeck Nodes")
+            .description("Pass authentication credentials from Rundeck nodes. IMPORTANT: Only applies to Ansible Playbook Workflow Steps. This feature does NOT work with Node Steps because they run independently per node and do not share the global inventory context.")
             .build();
 
     public static Property EXECUTABLE_PROP = PropertyUtil.freeSelect(

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -244,7 +244,7 @@ public interface AnsibleDescribable extends Describable {
             .booleanType(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH)
             .required(false)
             .title("Workflow Step: Generate Inventory and Pass Node Authentication from Rundeck Nodes")
-            .description("Pass authentication credentials from Rundeck nodes. IMPORTANT: Only applies to Ansible Playbook Workflow Steps. This feature does NOT work with Node Steps because they run independently per node and do not share the global inventory context.")
+            .description("Pass authentication credentials from Rundeck nodes for Ansible Playbook Workflow Steps only (not supported for Node Steps). See the Ansible plugin documentation for details.")
             .build();
 
     public static Property EXECUTABLE_PROP = PropertyUtil.freeSelect(

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -100,6 +100,7 @@ public interface AnsibleDescribable extends Describable {
     public static final String ANSIBLE_INVENTORY_INLINE = "ansible-inventory-inline";
     public static final String ANSIBLE_INVENTORY = "ansible-inventory";
     public static final String ANSIBLE_GENERATE_INVENTORY = "ansible-generate-inventory";
+    public static final String ANSIBLE_GENERATE_INVENTORY_NODES_AUTH = "ansible-generate-inventory-nodes-auth";
     public static final String ANSIBLE_MODULE = "ansible-module";
     public static final String ANSIBLE_MODULE_ARGS = "ansible-module-args";
     public static final String ANSIBLE_DEBUG = "ansible-debug";
@@ -232,6 +233,13 @@ public interface AnsibleDescribable extends Describable {
     .title("Generate inventory")
     .description("Generate Ansible inventory from Rundeck nodes.")
     .build();
+
+    static final Property GENERATE_INVENTORY_NODES_AUTH = PropertyBuilder.builder()
+            .booleanType(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH)
+            .required(false)
+            .title("Generate inventory, pass node authentication from rundeck nodes")
+            .description("Pass authentication from rundeck nodes.")
+            .build();
 
     public static Property EXECUTABLE_PROP = PropertyUtil.freeSelect(
               ANSIBLE_EXECUTABLE,

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleDescribable.java
@@ -237,8 +237,8 @@ public interface AnsibleDescribable extends Describable {
     static final Property GENERATE_INVENTORY_NODES_AUTH = PropertyBuilder.builder()
             .booleanType(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH)
             .required(false)
-            .title("Generate inventory, pass node authentication from rundeck nodes")
-            .description("Pass authentication from rundeck nodes.")
+            .title("Workflow Step: Generate inventory, pass node authentication from rundeck nodes")
+            .description("Pass authentication from rundeck nodes. Only applies to workflow steps.")
             .build();
 
     public static Property EXECUTABLE_PROP = PropertyUtil.freeSelect(

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -465,8 +465,8 @@ public class AnsibleRunner {
                             try {
                                 // Sanitize node name for filesystem use
                                 String safeNodeName = sanitizeNodeNameForFilesystem(nodeName);
-                                if(debug && !nodeName.equals(safeNodeName)) {
-                                    System.err.println("DEBUG: Sanitized node name '" + nodeName + "' to '" + safeNodeName + "' for temp file");
+                                if(!nodeName.equals(safeNodeName)) {
+                                    log.debug("Sanitized node name '{}' to '{}' for temp file", nodeName, safeNodeName);
                                 }
                                 tempHostPkFile = AnsibleUtil.createTemporaryFile("","id_rsa_node_"+safeNodeName, privateKey,customTmpDirPath);
 
@@ -489,10 +489,8 @@ public class AnsibleRunner {
                     // Build YAML content using helper method
                     String yamlContent = buildGroupVarsYaml(hostPasswords, hostUsers, hostKeys);
 
-                    if(debug){
-                        System.err.println("DEBUG: Building group_vars YAML with " + hostPasswords.size() + " passwords, " + hostUsers.size() + " users, and " + hostKeys.size() + " private keys");
-                        System.err.println("DEBUG: YAML content built successfully, length: " + yamlContent.length());
-                    }
+                    log.debug("Building group_vars YAML with {} passwords, {} users, and {} private keys", hostPasswords.size(), hostUsers.size(), hostKeys.size());
+                    log.debug("YAML content built successfully, length: {}", yamlContent.length());
 
                     try {
 
@@ -505,17 +503,13 @@ public class AnsibleRunner {
                         File inventoryFile = new File(inventory);
                         File inventoryParentDir = inventoryFile.getParentFile();
 
-                        if(debug) {
-                            System.err.println("DEBUG: inventoryFile: " + inventoryFile.getAbsolutePath());
-                            System.err.println("DEBUG: inventory file exists: " + inventoryFile.exists());
-                            System.err.println("DEBUG: inventoryParentDir: " + (inventoryParentDir != null ? inventoryParentDir.getAbsolutePath() : "null"));
-                        }
+                        log.debug("inventoryFile: {}", inventoryFile.getAbsolutePath());
+                        log.debug("inventory file exists: {}", inventoryFile.exists());
+                        log.debug("inventoryParentDir: {}", (inventoryParentDir != null ? inventoryParentDir.getAbsolutePath() : "null"));
 
                         if (inventoryParentDir != null) {
                             groupVarsDir = new File(inventoryParentDir, "group_vars");
-                            if(debug) {
-                                System.err.println("DEBUG: group_vars directory path: " + groupVarsDir.getAbsolutePath());
-                            }
+                            log.debug("group_vars directory path: {}", groupVarsDir.getAbsolutePath());
 
                             try {
                                 // Use Files.createDirectories() which is idempotent (safe to call if directory exists)
@@ -540,25 +534,19 @@ public class AnsibleRunner {
                                     "This file will be cleaned up after execution, but may persist if cleanup fails.",
                                     tempNodeAuthFile.getAbsolutePath());
 
-                            if(debug) {
-                                System.err.println("DEBUG: Writing all.yaml to: " + tempNodeAuthFile.getAbsolutePath());
-                                System.err.println("DEBUG: all.yaml written successfully, file size: " + tempNodeAuthFile.length() + " bytes");
-                            }
+                            log.debug("Writing all.yaml to: {}", tempNodeAuthFile.getAbsolutePath());
+                            log.debug("all.yaml written successfully, file size: {} bytes", tempNodeAuthFile.length());
                         } else {
                             // Fallback to temp file if inventory has no parent directory
                             tempNodeAuthFile = AnsibleUtil.createTemporaryFile("group_vars", "all.yaml", yamlContent, customTmpDirPath);
 
-                            if(debug) {
-                                System.err.println("DEBUG: No parent directory, using temporary file");
-                                System.err.println("DEBUG: Temporary all.yaml created at: " + tempNodeAuthFile.getAbsolutePath());
-                            }
+                            log.debug("No parent directory, using temporary file");
+                            log.debug("Temporary all.yaml created at: {}", tempNodeAuthFile.getAbsolutePath());
                         }
 
-                        if(debug) {
-                            System.err.println("DEBUG: tempNodeAuthFile: " + tempNodeAuthFile.getAbsolutePath());
-                            System.err.println("DEBUG: tempNodeAuthFile exists: " + tempNodeAuthFile.exists());
-                            System.err.println("DEBUG: tempNodeAuthFile readable: " + tempNodeAuthFile.canRead());
-                        }
+                        log.debug("tempNodeAuthFile: {}", tempNodeAuthFile.getAbsolutePath());
+                        log.debug("tempNodeAuthFile exists: {}", tempNodeAuthFile.exists());
+                        log.debug("tempNodeAuthFile readable: {}", tempNodeAuthFile.canRead());
 
                         //set extra vars to resolve the host specific authentication
                         if (!hostUsers.isEmpty()) {
@@ -1011,7 +999,7 @@ public class AnsibleRunner {
 
                 // Validate vault format
                 if (!isValidVaultFormat(vaultValue)) {
-                    System.err.println("ERROR: Invalid vault format for host: " + originalKey);
+                    log.error("Invalid vault format for host: {}", originalKey);
                     throw new RuntimeException("Invalid vault format for host: " + originalKey);
                 }
                 // The vault value already contains "!vault |\n" followed by the encrypted content
@@ -1047,9 +1035,7 @@ public class AnsibleRunner {
 
         String result = yamlContent.toString();
 
-        if(debug){
-            System.err.println("DEBUG: Generated YAML content (" + result.length() + " bytes)");
-        }
+        log.debug("Generated YAML content ({} bytes)", result.length());
 
         return result;
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -1030,7 +1030,7 @@ public class AnsibleRunner {
                     }
                 } else {
                     // Single line value (shouldn't happen with vault, but handle it)
-                    log.debug("Single line vault value for host: {}", originalKey);
+                    log.warn("Single line vault value for host: {}", originalKey);
                     yamlContent.append(vaultValue).append("\n");
                 }
             }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -614,14 +614,14 @@ public class AnsibleRunner {
                 String privateKeyData = sshPrivateKey.replaceAll("\r\n", "\n");
                 tempPkFile = AnsibleUtil.createTemporaryFile("","id_rsa", privateKeyData,customTmpDirPath);
 
-                // Set SSH private key permissions to 0400 (owner read-only).
-                // This is a security best practice: private keys should never be writable after creation.
-                // SSH itself will warn or refuse to use keys with overly permissive permissions (e.g., 0600).
-                // Write permission is unnecessary since this temporary file is created once, read by SSH,
-                // and never modified. The file will be deleted after use.
-                // Node-specific private keys created elsewhere in this class should use the same 0400 permissions for consistency.
+                // Set SSH private key permissions to 0600 (owner read/write).
+                // This keeps the key private (not accessible by group/world) while preserving backward
+                // compatibility for workflows that may need to modify or reuse this temporary file.
+                // SSH itself will warn or refuse to use keys with overly permissive permissions, so we
+                // restrict access to the file owner only.
                 Set<PosixFilePermission> perms = new HashSet<PosixFilePermission>();
                 perms.add(PosixFilePermission.OWNER_READ);
+                perms.add(PosixFilePermission.OWNER_WRITE);
                 Files.setPosixFilePermissions(tempPkFile.toPath(), perms);
 
                 if (sshUseAgent) {

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -541,7 +541,10 @@ public class AnsibleRunner {
                         if(!hostPasswords.isEmpty()){
                             procArgs.add("-e ansible_password=\"{{ host_passwords[inventory_hostname] }}\"");
                         }
-                        procArgs.add("-e ansible_ssh_private_key_file=\"{{ host_private_keys[inventory_hostname] }}\"");
+
+                        if(!hostKeys.isEmpty()){
+                            procArgs.add("-e ansible_ssh_private_key_file=\"{{ host_private_keys[inventory_hostname] }}\"");
+                        }
 
                     } catch (IOException e) {
                         System.err.println("ERROR: Failed to write all.yaml: " + e.getMessage());

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -884,7 +884,7 @@ public class AnsibleRunner {
      * @param hostUsers Map of host names to usernames
      * @return YAML content string ready to be written to all.yaml
      */
-    private String buildGroupVarsYaml(Map<String, String> hostPasswords, Map<String, String> hostUsers) {
+    String buildGroupVarsYaml(Map<String, String> hostPasswords, Map<String, String> hostUsers) {
 
         StringBuilder yamlContent = new StringBuilder();
         yamlContent.append("host_passwords:\n");
@@ -950,13 +950,13 @@ public class AnsibleRunner {
      * @param key The key to escape
      * @return Escaped key safe for YAML
      */
-    private String escapeYamlKey(String key) {
-        // YAML special characters that require quoting
-        if (key.matches(".*[:\\[\\]{}#&*!|>'\"%@`].*") ||
+    String escapeYamlKey(String key) {
+        // YAML special characters that require quoting (including backslash)
+        if (key.matches(".*[:\\[\\]{}#&*!|>'\"%@`\\\\].*") ||
             key.startsWith("-") ||
             key.startsWith("?") ||
             key.matches("^[0-9].*")) {
-            // Escape any existing quotes and wrap in quotes
+            // Escape any existing backslashes and quotes, then wrap in quotes
             return "\"" + key.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
         }
         return key;
@@ -969,13 +969,13 @@ public class AnsibleRunner {
      * @param value The value to escape
      * @return Escaped value safe for YAML
      */
-    private String escapeYamlValue(String value) {
-        // Check if value needs quoting
-        if (value.matches(".*[:\\[\\]{}#&*!|>'\"%@`].*") ||
+    String escapeYamlValue(String value) {
+        // Check if value needs quoting (including backslash)
+        if (value.matches(".*[:\\[\\]{}#&*!|>'\"%@`\\\\].*") ||
             value.startsWith("-") ||
             value.startsWith("?") ||
             value.trim().isEmpty()) {
-            // Escape any existing quotes and wrap in quotes
+            // Escape any existing backslashes and quotes, then wrap in quotes
             return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
         }
         return value;
@@ -988,7 +988,7 @@ public class AnsibleRunner {
      * @param vaultValue The vault value to validate
      * @return true if valid vault format, false otherwise
      */
-    private boolean isValidVaultFormat(String vaultValue) {
+    boolean isValidVaultFormat(String vaultValue) {
         if (vaultValue == null || vaultValue.trim().isEmpty()) {
             return false;
         }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -573,8 +573,7 @@ public class AnsibleRunner {
                         }
 
                     } catch (IOException e) {
-                        System.err.println("ERROR: Failed to write all.yaml: " + e.getMessage());
-                        e.printStackTrace();
+                        log.error("ERROR: Failed to write all.yaml for node auth", e);
                         throw new RuntimeException("Failed to write all.yaml for node auth", e);
                     }
                 }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -619,8 +619,8 @@ public class AnsibleRunner {
                 // This is a security best practice: private keys should never be writable after creation.
                 // SSH itself will warn or refuse to use keys with overly permissive permissions (e.g., 0600).
                 // Write permission is unnecessary since this temporary file is created once, read by SSH,
-                // and never modified. The file will be deleted after use. This matches the permissions
-                // used for node-specific private keys (lines 474-476).
+                // and never modified. The file will be deleted after use.
+                // Node-specific private keys created elsewhere in this class should use the same 0400 permissions for consistency.
                 Set<PosixFilePermission> perms = new HashSet<PosixFilePermission>();
                 perms.add(PosixFilePermission.OWNER_READ);
                 Files.setPosixFilePermissions(tempPkFile.toPath(), perms);

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -1293,8 +1293,8 @@ public class AnsibleRunner {
         // Replace unsafe characters with underscores
         String safeNodeName = nodeName.replaceAll("[^a-zA-Z0-9._-]", "_");
 
-        // Prevent hidden files (starting with .) and problematic names (empty or all dots)
-        if (safeNodeName.isEmpty() || safeNodeName.startsWith(".") || safeNodeName.matches("^\\.+$")) {
+        // Prevent hidden files (starting with .) and problematic names (empty)
+        if (safeNodeName.isEmpty() || safeNodeName.startsWith(".")) {
             safeNodeName = "_" + safeNodeName;
         }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -535,7 +535,7 @@ public class AnsibleRunner {
                             );
 
                             // Alert administrators that sensitive files are being created in their inventory directory
-                            log.warn("Writing vault-encrypted authentication data to user-provided inventory location: {}. " +
+                            log.info("Writing vault-encrypted authentication data to user-provided inventory location: {}. " +
                                     "Administrators should ensure this directory has appropriate filesystem permissions. " +
                                     "This file will be cleaned up after execution, but may persist if cleanup fails.",
                                     tempNodeAuthFile.getAbsolutePath());

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -1082,7 +1082,24 @@ public class AnsibleRunner {
 
     /**
      * Pattern for detecting YAML special characters that require quoting.
-     * Includes: : [ ] { } # & * ! | > ' " % @ ` \
+     * Matches any string containing one or more of these characters:
+     * <ul>
+     *   <li><code>:</code> - colon (key-value separator)</li>
+     *   <li><code>[ ]</code> - square brackets (array notation)</li>
+     *   <li><code>{ }</code> - curly braces (object notation)</li>
+     *   <li><code>#</code> - hash (comment marker)</li>
+     *   <li><code>&</code> - ampersand (anchor reference)</li>
+     *   <li><code>*</code> - asterisk (alias reference)</li>
+     *   <li><code>!</code> - exclamation (tag indicator)</li>
+     *   <li><code>|</code> - pipe (literal block scalar)</li>
+     *   <li><code>&gt;</code> - greater-than (folded block scalar)</li>
+     *   <li><code>' "</code> - quotes (string delimiters)</li>
+     *   <li><code>%</code> - percent (directive indicator)</li>
+     *   <li><code>@</code> - at-sign (reserved for future use)</li>
+     *   <li><code>`</code> - backtick (reserved for future use)</li>
+     *   <li><code>\</code> - backslash (escape character)</li>
+     * </ul>
+     * Regex pattern: <code>.*[:\\[\\]{}#&amp;*!|&gt;'\"%@`\\\\].*</code>
      */
     private static final java.util.regex.Pattern YAML_SPECIAL_CHARS_PATTERN =
             java.util.regex.Pattern.compile(".*[:\\[\\]{}#&*!|>'\"%@`\\\\].*");

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -423,7 +423,7 @@ public class AnsibleRunner {
 
                     host_passwords:
                         host1: enc(password1)
-                        host2: enc(password1)
+                        host2: enc(password2)
 
                     host_private_keys:
                         host1: /path/to/private_key1
@@ -620,7 +620,7 @@ public class AnsibleRunner {
                 // SSH itself will warn or refuse to use keys with overly permissive permissions (e.g., 0600).
                 // Write permission is unnecessary since this temporary file is created once, read by SSH,
                 // and never modified. The file will be deleted after use. This matches the permissions
-                // used for node-specific private keys (lines 469-472).
+                // used for node-specific private keys (lines 474-476).
                 Set<PosixFilePermission> perms = new HashSet<PosixFilePermission>();
                 perms.add(PosixFilePermission.OWNER_READ);
                 Files.setPosixFilePermissions(tempPkFile.toPath(), perms);

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -942,10 +942,7 @@ public class AnsibleRunner {
         String result = yamlContent.toString();
 
         if(debug){
-            System.err.println("DEBUG: Generated YAML content (" + result.length() + " bytes):");
-            System.err.println("DEBUG: ========== YAML START ==========");
-            System.err.println(result);
-            System.err.println("DEBUG: ========== YAML END ==========");
+            System.err.println("DEBUG: Generated YAML content (" + result.length() + " bytes)");
         }
 
         return result;

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -552,7 +552,11 @@ public class AnsibleRunner {
             }
 
             if (sshUsePassword) {
-                String extraVarsPassword = "ansible_password: " + sshPass;
+                // Escape special characters in the password to prevent YAML parsing errors
+                String escapedPassword = escapePasswordForYaml(sshPass);
+
+                // Wrap in quotes to preserve special characters
+                String extraVarsPassword = "ansible_password: \"" + escapedPassword + "\"";
                 String finalextraVarsPassword = extraVarsPassword;
 
                 if(useAnsibleVault){
@@ -571,7 +575,11 @@ public class AnsibleRunner {
                 procArgs.add("--become");
 
                 if (becomePassword != null && !becomePassword.isEmpty()) {
-                    String extraVarsPassword = "ansible_become_password: " + becomePassword;
+                    // Escape special characters in the password to prevent YAML parsing errors
+                    String escapedPassword = escapePasswordForYaml(becomePassword);
+
+                    // Wrap in quotes to preserve special characters
+                    String extraVarsPassword = "ansible_become_password: \"" + escapedPassword + "\"";
                     String finalextraVarsPassword = extraVarsPassword;
 
                     if (useAnsibleVault) {
@@ -979,6 +987,22 @@ public class AnsibleRunner {
             return "\"" + value.replace("\\", "\\\\").replace("\"", "\\\"") + "\"";
         }
         return value;
+    }
+
+    /**
+     * Escapes a password value for safe use in YAML.
+     * Always wraps the password in quotes and escapes special characters to prevent YAML parsing errors.
+     *
+     * @param password The password to escape
+     * @return Escaped and quoted password safe for YAML
+     */
+    String escapePasswordForYaml(String password) {
+        // Escape special characters in the password to prevent YAML parsing errors
+        return password
+            .replace("\\", "\\\\")
+            .replace("\"", "\\\"")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r");
     }
 
     /**

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -1286,10 +1286,26 @@ public class AnsibleRunner {
 
     /**
      * Sanitizes a node name to be safe for use in filesystem paths.
-     * Replaces unsafe characters with underscores and prevents hidden files and problematic names.
+     * <p>
+     * This method performs the following transformations:
+     * <ul>
+     *   <li>Replaces all characters except alphanumeric, dot, underscore, and hyphen with underscores</li>
+     *   <li>Prevents hidden files by prepending underscore if name starts with dot</li>
+     *   <li>Handles empty strings by prepending underscore</li>
+     * </ul>
+     * </p>
+     * <p>
+     * Examples:
+     * <ul>
+     *   <li>{@code "node-1"} → {@code "node-1"} (no change)</li>
+     *   <li>{@code "node@host"} → {@code "node_host"} (@ replaced)</li>
+     *   <li>{@code ".hidden"} → {@code "_.hidden"} (prevents hidden file)</li>
+     *   <li>{@code ""} → {@code "_"} (handles empty)</li>
+     * </ul>
+     * </p>
      *
-     * @param nodeName The original node name
-     * @return A sanitized node name safe for use in file paths
+     * @param nodeName The original node name to sanitize
+     * @return A sanitized node name safe for use in file paths, never null
      */
     String sanitizeNodeNameForFilesystem(String nodeName) {
         // Replace unsafe characters with underscores

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -457,7 +457,12 @@ public class AnsibleRunner {
                             //create temporary file for private key
                             File tempHostPkFile;
                             try {
-                                tempHostPkFile = AnsibleUtil.createTemporaryFile("","id_rsa_node_"+nodeName, privateKey,customTmpDirPath);
+                                // Sanitize node name for filesystem use (replace unsafe characters with underscores)
+                                String safeNodeName = nodeName.replaceAll("[^a-zA-Z0-9._-]", "_");
+                                if(debug && !nodeName.equals(safeNodeName)) {
+                                    System.err.println("DEBUG: Sanitized node name '" + nodeName + "' to '" + safeNodeName + "' for temp file");
+                                }
+                                tempHostPkFile = AnsibleUtil.createTemporaryFile("","id_rsa_node_"+safeNodeName, privateKey,customTmpDirPath);
 
                                 // Only the owner can read and write
                                 Set<PosixFilePermission> perms = new HashSet<PosixFilePermission>();

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunner.java
@@ -446,7 +446,8 @@ public class AnsibleRunner {
                                 try {
                                     encryptedPassword = ansibleVault.encryptVariable("ansible_password", password);
                                 } catch (Exception e) {
-                                    throw new RuntimeException(e);
+                                    throw new RuntimeException("Failed to encrypt password for node '" +
+                                            nodeName + "' using Ansible Vault: " + e.getMessage(), e);
                                 }
                             }
                             hostPasswords.put(nodeName, encryptedPassword);
@@ -468,7 +469,8 @@ public class AnsibleRunner {
 
                                 tempHostPkFile.deleteOnExit();
                             } catch (IOException e) {
-                                throw new RuntimeException(e);
+                                throw new RuntimeException("Failed to create temporary private key file for node '" +
+                                        nodeName + "': " + e.getMessage(), e);
                             }
                         }
                     });

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -226,8 +226,9 @@ public class AnsibleRunnerContextBuilder {
      *
      * @param storagePath The storage path to read from
      * @param resourceType Description of resource type for error messages (e.g., "ssh password", "ssh private key")
-     * @return The content as a UTF-8 string, or null if storagePath is null
-     * @throws ConfigurationException if reading fails
+     * @return The content as a UTF-8 string. Returns null ONLY if storagePath parameter is null (early return).
+     *         After attempting to read content, this method either returns a non-null string or throws an exception.
+     * @throws ConfigurationException if the storage path cannot be read or does not exist
      */
     private String readFromStoragePath(String storagePath, String resourceType) throws ConfigurationException {
         if (storagePath == null) {

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -946,7 +946,7 @@ public class AnsibleRunnerContextBuilder {
 
         this.context.getNodes().forEach((node) -> {
             String keyPath = PropertyResolver.resolveProperty(
-                    AnsibleDescribable.ANSIBLE_SSH_KEYPATH,
+                    AnsibleDescribable.ANSIBLE_SSH_PASSWORD_STORAGE_PATH,
                     null,
                     getFrameworkProject(),
                     getFramework(),
@@ -958,7 +958,6 @@ public class AnsibleRunnerContextBuilder {
                 if(!secretPaths.contains(keyPath)){
                     secretPaths.add(keyPath);
                 }
-
             }
         });
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -1018,31 +1018,17 @@ public class AnsibleRunnerContextBuilder {
 
 
     public Boolean generateInventoryNodesAuth() {
-        Boolean generateInventoryNodesAuth = null;
-        String sgenerateInventoryNodesAuth = PropertyResolver.resolveProperty(
-                AnsibleDescribable.ANSIBLE_GENERATE_INVENTORY_NODES_AUTH,
-                null,
-                getFrameworkProject(),
-                getFramework(),
-                getNode(),
-                getJobConf()
-        );
-
-        if (null != sgenerateInventoryNodesAuth) {
-            generateInventoryNodesAuth = Boolean.parseBoolean(sgenerateInventoryNodesAuth);
+        // Only use plugin group configuration
+        if (this.pluginGroup != null && this.pluginGroup.getGenerateInventoryNodesAuth() != null) {
+            Boolean generateInventoryNodesAuth = this.pluginGroup.getGenerateInventoryNodesAuth();
+            this.context.getExecutionLogger().log(
+                    4, "Using plugin group configuration for generateInventoryNodesAuth: " + generateInventoryNodesAuth
+            );
+            return generateInventoryNodesAuth;
         }
 
-        // Fallback to plugin group configuration if not set
-        if (generateInventoryNodesAuth == null || !generateInventoryNodesAuth) {
-            if (this.pluginGroup != null && this.pluginGroup.getGenerateInventoryNodesAuth() != null && this.pluginGroup.getGenerateInventoryNodesAuth()) {
-                this.context.getExecutionLogger().log(
-                        4, "plugin group set getGenerateInventoryNodesAuth: " + this.pluginGroup.getGenerateInventoryNodesAuth()
-                );
-                generateInventoryNodesAuth = this.pluginGroup.getGenerateInventoryNodesAuth();
-            }
-        }
-
-        return generateInventoryNodesAuth;
+        // Default to false if not configured
+        return false;
     }
 
     /**

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -1075,7 +1075,7 @@ public class AnsibleRunnerContextBuilder {
             String userName = getSshNodeUser(node);
 
             if(null!=userName){
-                auth.put("ansible_user",userName );
+                auth.put("ansible_user", userName);
             }
 
             // Validate that node has at least one authentication method configured

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -775,7 +775,7 @@ public class AnsibleRunnerContextBuilder {
     public void cleanupTempFiles() {
         // Clean up individual temp files
         for (File temp : tempFiles) {
-            if (!getDebug()) {
+            if (getDebug()) {
                 System.err.println("DEBUG: Deleting temp file: " + temp.getAbsolutePath());
             }
             temp.delete();

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -256,15 +256,7 @@ public class AnsibleRunnerContextBuilder {
 
     public String getSshNodeUser(INodeEntry node) {
         final String user;
-        user = PropertyResolver.resolveProperty(
-                AnsibleDescribable.ANSIBLE_SSH_USER,
-                null,
-                getFrameworkProject(),
-                getFramework(),
-                node,
-                getJobConf()
-        );
-
+        user = node.getUsername();
         if (null != user && user.contains("${")) {
             return DataContextUtils.replaceDataReferencesInString(user, getContext().getDataContext());
         }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -1047,6 +1047,10 @@ public class AnsibleRunnerContextBuilder {
 
     public List<String> getListNodesKeyPath(){
 
+        if(!generateInventoryNodesAuth()) {
+            return new ArrayList<>();
+        }
+
         List<String> secretPaths = new ArrayList<>();
 
         this.context.getNodes().forEach((node) -> {
@@ -1062,6 +1066,21 @@ public class AnsibleRunnerContextBuilder {
             if(null!=keyPath){
                 if(!secretPaths.contains(keyPath)){
                     secretPaths.add(keyPath);
+                }
+            }
+
+            String privateKeyPath = PropertyResolver.resolveProperty(
+                    AnsibleDescribable.ANSIBLE_SSH_KEYPATH_STORAGE_PATH,
+                    null,
+                    getFrameworkProject(),
+                    getFramework(),
+                    node,
+                    getJobConf()
+            );
+
+            if(null!=privateKeyPath){
+                if(!secretPaths.contains(privateKeyPath)){
+                    secretPaths.add(privateKeyPath);
                 }
             }
         });

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -165,7 +165,7 @@ public class AnsibleRunnerContextBuilder {
             final String path = getPrivateKeyfilePath();
             if (path != null) {
                 try {
-                    return new String(Files.readAllBytes(Paths.get(path)));
+                    return new String(Files.readAllBytes(Paths.get(path)), java.nio.charset.StandardCharsets.UTF_8);
                 } catch (IOException e) {
                     throw new ConfigurationException("Failed to read the ssh private key from path " +
                             path + ": " + e.getMessage());

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -1117,7 +1117,7 @@ public class AnsibleRunnerContextBuilder {
 
 
     public Boolean generateInventoryNodesAuth() {
-        Boolean generateInventoryNodesAuth = null;
+        boolean generateInventoryNodesAuth = false;
 
         log.debug("Resolving property ANSIBLE_GENERATE_INVENTORY_NODES_AUTH");
         log.debug("Property key: {}", AnsibleDescribable.ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -777,8 +777,8 @@ public class AnsibleRunnerContextBuilder {
         for (File temp : tempFiles) {
             if (!getDebug()) {
                 System.err.println("DEBUG: Deleting temp file: " + temp.getAbsolutePath());
-                temp.delete();
             }
+            temp.delete();
         }
         tempFiles.clear();
 
@@ -787,15 +787,7 @@ public class AnsibleRunnerContextBuilder {
             if (getDebug()) {
                 System.err.println("DEBUG: Execution-specific directory exists: " + executionSpecificDir.getAbsolutePath());
             }
-            if (!getDebug()) {
-                deleteDirectoryRecursively(executionSpecificDir);
-            } else {
-                System.err.println("DEBUG: Skipping cleanup due to debug mode");
-            }
-        } else {
-            if (getDebug()) {
-                System.err.println("DEBUG: No execution-specific directory to cleanup");
-            }
+            deleteDirectoryRecursively(executionSpecificDir);
         }
     }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -783,8 +783,6 @@ public class AnsibleRunnerContextBuilder {
 
 
     public void cleanupTempFiles() {
-        System.err.println("DEBUG: cleanupTempFiles called");
-
         // Clean up individual temp files
         for (File temp : tempFiles) {
             if (!getDebug()) {
@@ -796,7 +794,9 @@ public class AnsibleRunnerContextBuilder {
 
         // Clean up execution-specific directory (including group_vars)
         if (executionSpecificDir != null && executionSpecificDir.exists()) {
-            System.err.println("DEBUG: Execution-specific directory exists: " + executionSpecificDir.getAbsolutePath());
+            if (getDebug()) {
+                System.err.println("DEBUG: Execution-specific directory exists: " + executionSpecificDir.getAbsolutePath());
+            }
             if (!getDebug()) {
                 System.err.println("DEBUG: Deleting execution-specific directory recursively");
                 deleteDirectoryRecursively(executionSpecificDir);
@@ -954,8 +954,6 @@ public class AnsibleRunnerContextBuilder {
 
         Map<String, Map<String, String>> authenticationNodesMap = new HashMap<>();
 
-        System.err.println("DEBUG: getNodesAuthenticationMap called");
-
         this.context.getNodes().forEach((node) -> {
             String keyPath = PropertyResolver.resolveProperty(
                     AnsibleDescribable.ANSIBLE_SSH_PASSWORD_STORAGE_PATH,
@@ -966,16 +964,11 @@ public class AnsibleRunnerContextBuilder {
                     getJobConf()
             );
 
-            System.err.println("DEBUG: Node " + node.getNodename() + " keyPath: " + keyPath);
-
             Map<String, String> auth = new HashMap<>();
 
             if(null!=keyPath){
                 try {
                     String password = getPasswordFromPath(keyPath);
-                    System.err.println("DEBUG: Retrieved password for " + node.getNodename() + ": " + (password != null ? password.substring(0, Math.min(3, password.length())) + "..." : "null"));
-                    System.err.println("DEBUG: Password length: " + (password != null ? password.length() : 0));
-                    System.err.println("DEBUG: Password bytes: " + (password != null ? java.util.Arrays.toString(password.getBytes("UTF-8")) : "null"));
                     auth.put("ansible_password", password);
                 } catch (ConfigurationException e) {
                     System.err.println("DEBUG: Error retrieving password for " + node.getNodename() + ": " + e.getMessage());
@@ -987,7 +980,6 @@ public class AnsibleRunnerContextBuilder {
 
             }
             String userName = getSshNodeUser(node);
-            System.err.println("DEBUG: Node " + node.getNodename() + " userName: " + userName);
 
             if(null!=userName){
                 auth.put("ansible_user",userName );
@@ -996,7 +988,6 @@ public class AnsibleRunnerContextBuilder {
             authenticationNodesMap.put(node.getNodename(), auth);
         });
 
-        System.err.println("DEBUG: authenticationNodesMap has " + authenticationNodesMap.size() + " entries");
         return authenticationNodesMap;
     }
 
@@ -1073,7 +1064,10 @@ public class AnsibleRunnerContextBuilder {
         // Get execution ID from data context
         if (context.getDataContext() != null && context.getDataContext().get("job") != null) {
             executionId = context.getDataContext().get("job").get("execid");
-            System.err.println("DEBUG: Execution ID from context: " + executionId);
+
+            if (getDebug()) {
+                System.err.println("DEBUG: Execution ID from context: " + executionId);
+            }
         }
 
         // Get base tmp directory
@@ -1083,16 +1077,15 @@ public class AnsibleRunnerContextBuilder {
         if (executionId != null && !executionId.isEmpty()) {
             executionSpecificDir = new File(baseTmpDir, "ansible-exec-" + executionId);
             if (!executionSpecificDir.exists()) {
-                System.err.println("DEBUG: Creating execution-specific directory: " + executionSpecificDir.getAbsolutePath());
+                if (getDebug()) {
+                    System.err.println("DEBUG: Creating execution-specific directory: " + executionSpecificDir.getAbsolutePath());
+                }
                 executionSpecificDir.mkdirs();
             } else {
                 System.err.println("DEBUG: Execution-specific directory already exists: " + executionSpecificDir.getAbsolutePath());
             }
             return executionSpecificDir.getAbsolutePath();
         }
-
-        // Fallback to base tmp dir if execution ID is not available
-        System.err.println("DEBUG: No execution ID found, falling back to base tmp dir: " + baseTmpDir);
         return baseTmpDir;
     }
 }

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -953,10 +953,14 @@ public class AnsibleRunnerContextBuilder {
                     String password = getPasswordFromPath(keyPath);
                     auth.put("ansible_password", password);
                 } catch (ConfigurationException e) {
-                    System.err.println("DEBUG: Error retrieving password for " + node.getNodename() + ": " + e.getMessage());
+                    if (getDebug()) {
+                        System.err.println("DEBUG: Error retrieving password for " + node.getNodename() + ": " + e.getMessage());
+                    }
                     throw new RuntimeException(e);
                 } catch (Exception e2) {
-                    System.err.println("DEBUG: Unexpected error: " + e2.getMessage());
+                    if (getDebug()) {
+                        System.err.println("DEBUG: Unexpected error: " + e2.getMessage());
+                    }
                     throw new RuntimeException(e2);
                 }
 
@@ -1045,7 +1049,9 @@ public class AnsibleRunnerContextBuilder {
     String getExecutionSpecificTmpDir() {
         // Return cached directory if already created
         if (executionSpecificDir != null) {
-            System.err.println("DEBUG: Using cached execution-specific directory: " + executionSpecificDir.getAbsolutePath());
+            if (getDebug()) {
+                System.err.println("DEBUG: Using cached execution-specific directory: " + executionSpecificDir.getAbsolutePath());
+            }
             return executionSpecificDir.getAbsolutePath();
         }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerContextBuilder.java
@@ -1042,7 +1042,7 @@ public class AnsibleRunnerContextBuilder {
      *
      * @return The path to the execution-specific directory
      */
-    private String getExecutionSpecificTmpDir() {
+    String getExecutionSpecificTmpDir() {
         // Return cached directory if already created
         if (executionSpecificDir != null) {
             System.err.println("DEBUG: Using cached execution-specific directory: " + executionSpecificDir.getAbsolutePath());

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleModuleWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleModuleWorkflowStep.java
@@ -72,11 +72,7 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, AnsibleDescribable
         }
 
         // set log level
-        String loglevel = null;
-        if (context.getDataContext() != null &&
-            context.getDataContext().get("job") != null) {
-            loglevel = context.getDataContext().get("job").get("loglevel");
-        }
+        String loglevel = AnsibleUtil.getJobLogLevel(context);
 
         if ("DEBUG".equals(loglevel)) {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG, "True");

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleModuleWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleModuleWorkflowStep.java
@@ -72,7 +72,13 @@ public class AnsibleModuleWorkflowStep implements StepPlugin, AnsibleDescribable
         }
 
         // set log level
-        if (context.getDataContext().get("job").get("loglevel").equals("DEBUG")) {
+        String loglevel = null;
+        if (context.getDataContext() != null &&
+            context.getDataContext().get("job") != null) {
+            loglevel = context.getDataContext().get("job").get("loglevel");
+        }
+
+        if ("DEBUG".equals(loglevel)) {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG, "True");
         } else {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG, "False");

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleNodeExecutor.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleNodeExecutor.java
@@ -36,6 +36,7 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable, Pr
         builder.property(WINDOWS_EXECUTABLE_PROP);
         builder.property(CONFIG_FILE_PATH);
         builder.property(GENERATE_INVENTORY_PROP);
+        builder.property(GENERATE_INVENTORY_NODES_AUTH);
         builder.property(SSH_AUTH_TYPE_PROP);
         builder.property(SSH_USER_PROP);
         builder.property(SSH_PASSWORD_STORAGE_PROP);
@@ -63,6 +64,8 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable, Pr
         builder.frameworkMapping(ANSIBLE_CONFIG_FILE_PATH,FWK_PROP_PREFIX + ANSIBLE_CONFIG_FILE_PATH);
         builder.mapping(ANSIBLE_GENERATE_INVENTORY,PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
         builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY,FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
+        builder.mapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH,PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
+        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH,FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
         builder.mapping(ANSIBLE_SSH_AUTH_TYPE,PROJ_PROP_PREFIX + ANSIBLE_SSH_AUTH_TYPE);
         builder.frameworkMapping(ANSIBLE_SSH_AUTH_TYPE,FWK_PROP_PREFIX + ANSIBLE_SSH_AUTH_TYPE);
         builder.mapping(ANSIBLE_SSH_USER,PROJ_PROP_PREFIX + ANSIBLE_SSH_USER);
@@ -197,7 +200,13 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable, Pr
         jobConf.put(AnsibleDescribable.ANSIBLE_LIMIT,node.getNodename());
         AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(node, context, context.getFramework(), jobConf);
 
-        return AnsibleUtil.getSecretsPath(builder);
+        List<String> secretPaths = AnsibleUtil.getSecretsPath(builder);
+        List<String> secretPathsNodes = builder.getListNodesKeyPath();
+
+        if(secretPathsNodes != null && !secretPathsNodes.isEmpty()){
+            secretPaths.addAll(secretPathsNodes);
+        }
+        return secretPaths;
     }
 }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleNodeExecutor.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleNodeExecutor.java
@@ -200,13 +200,7 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable, Pr
         jobConf.put(AnsibleDescribable.ANSIBLE_LIMIT,node.getNodename());
         AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(node, context, context.getFramework(), jobConf);
 
-        List<String> secretPaths = AnsibleUtil.getSecretsPath(builder);
-        List<String> secretPathsNodes = builder.getListNodesKeyPath();
-
-        if(secretPathsNodes != null && !secretPathsNodes.isEmpty()){
-            secretPaths.addAll(secretPathsNodes);
-        }
-        return secretPaths;
+        return AnsibleUtil.getSecretsPath(builder);
     }
 }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleNodeExecutor.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsibleNodeExecutor.java
@@ -200,7 +200,13 @@ public class AnsibleNodeExecutor implements NodeExecutor, AnsibleDescribable, Pr
         jobConf.put(AnsibleDescribable.ANSIBLE_LIMIT,node.getNodename());
         AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(node, context, context.getFramework(), jobConf);
 
-        return AnsibleUtil.getSecretsPath(builder);
+        List<String> secretPaths = AnsibleUtil.getSecretsPath(builder);
+        List<String> secretPathsNodes = builder.getListNodesKeyPath();
+
+        if(secretPathsNodes != null && !secretPathsNodes.isEmpty()){
+            secretPaths.addAll(secretPathsNodes);
+        }
+        return secretPaths;
     }
 }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
@@ -79,11 +79,7 @@ public class AnsiblePlaybookInlineWorkflowNodeStep implements NodeStepPlugin, An
         configuration.put(AnsibleDescribable.ANSIBLE_LIMIT,entry.getNodename());
 
         // set log level
-        String loglevel = null;
-        if (context.getDataContext() != null &&
-            context.getDataContext().get("job") != null) {
-            loglevel = context.getDataContext().get("job").get("loglevel");
-        }
+        String loglevel = AnsibleUtil.getJobLogLevel(context);
 
         if ("DEBUG".equals(loglevel)) {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"True");

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
@@ -43,8 +43,6 @@ public class AnsiblePlaybookInlineWorkflowNodeStep implements NodeStepPlugin, An
         builder.property(PLAYBOOK_INLINE_PROP);
         builder.property(EXTRA_VARS_PROP);
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
-        builder.property(GENERATE_INVENTORY_PROP);
-        builder.property(GENERATE_INVENTORY_NODES_AUTH);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);
         builder.property(EXTRA_ATTRS_PROP);
@@ -123,13 +121,7 @@ public class AnsiblePlaybookInlineWorkflowNodeStep implements NodeStepPlugin, An
     @Override
     public List<String> listSecretsPathWorkflowNodeStep(ExecutionContext context, INodeEntry node, Map<String, Object> configuration) {
         AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(node, context, context.getFramework(), configuration);
-        List<String> secretPaths = AnsibleUtil.getSecretsPath(builder);
-        List<String> secretPathsNodes = builder.getListNodesKeyPath();
-
-        if(secretPathsNodes != null && !secretPathsNodes.isEmpty()){
-            secretPaths.addAll(secretPathsNodes);
-        }
-        return secretPaths;
+        return AnsibleUtil.getSecretsPath(builder);
     }
 
     @Override

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
@@ -79,7 +79,13 @@ public class AnsiblePlaybookInlineWorkflowNodeStep implements NodeStepPlugin, An
         configuration.put(AnsibleDescribable.ANSIBLE_LIMIT,entry.getNodename());
 
         // set log level
-        if (context.getDataContext().get("job").get("loglevel").equals("DEBUG")) {
+        String loglevel = null;
+        if (context.getDataContext() != null &&
+            context.getDataContext().get("job") != null) {
+            loglevel = context.getDataContext().get("job").get("loglevel");
+        }
+
+        if ("DEBUG".equals(loglevel)) {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"True");
         } else {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"False");

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowNodeStep.java
@@ -43,6 +43,8 @@ public class AnsiblePlaybookInlineWorkflowNodeStep implements NodeStepPlugin, An
         builder.property(PLAYBOOK_INLINE_PROP);
         builder.property(EXTRA_VARS_PROP);
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
+        builder.property(GENERATE_INVENTORY_PROP);
+        builder.property(GENERATE_INVENTORY_NODES_AUTH);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);
         builder.property(EXTRA_ATTRS_PROP);
@@ -121,7 +123,13 @@ public class AnsiblePlaybookInlineWorkflowNodeStep implements NodeStepPlugin, An
     @Override
     public List<String> listSecretsPathWorkflowNodeStep(ExecutionContext context, INodeEntry node, Map<String, Object> configuration) {
         AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(node, context, context.getFramework(), configuration);
-        return AnsibleUtil.getSecretsPath(builder);
+        List<String> secretPaths = AnsibleUtil.getSecretsPath(builder);
+        List<String> secretPathsNodes = builder.getListNodesKeyPath();
+
+        if(secretPathsNodes != null && !secretPathsNodes.isEmpty()){
+            secretPaths.addAll(secretPathsNodes);
+        }
+        return secretPaths;
     }
 
     @Override

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
@@ -43,8 +43,6 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         builder.property(PLAYBOOK_INLINE_PROP);
         builder.property(EXTRA_VARS_PROP);
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
-        builder.property(GENERATE_INVENTORY_PROP);
-        builder.property(GENERATE_INVENTORY_NODES_AUTH);
         builder.property(INVENTORY_INLINE_PROP);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
@@ -37,6 +37,10 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         builder.name(SERVICE_PROVIDER_NAME);
         builder.title("Ansible Playbook Inline");
         builder.description("Runs an Inline Ansible Playbook.");
+        builder.metadata(
+                "automaticWorkflowStepRunnerAssociation",
+                "true"
+        );
 
         builder.property(BINARIES_DIR_PATH_PROP);
         builder.property(BASE_DIR_PROP);
@@ -93,8 +97,19 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
                 configuration,
                 pluginGroup);
 
+
         try {
             runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
+
+            Boolean generateInventoryNodeAuth = contextBuilder.generateInventoryNodesAuth();
+            if(generateInventoryNodeAuth != null && generateInventoryNodeAuth){
+                Map<String, Map<String, String>> nodesAuth = contextBuilder.getNodesAuthenticationMap();
+                if (nodesAuth != null && !nodesAuth.isEmpty()) {
+                    runner.setAddNodeAuthToInventory(true);
+                    runner.setNodesAuthentication(nodesAuth);
+                }
+            }
+
             runner.setCustomTmpDirPath(AnsibleUtil.getCustomTmpPathDir(contextBuilder.getFramework()));
         } catch (ConfigurationException e) {
             throw new StepException("Error configuring Ansible runner: " + e.getMessage(), e, AnsibleException.AnsibleFailureReason.ParseArgumentsError);
@@ -132,7 +147,7 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
     @Override
     public List<String> listSecretsPathWorkflowStep(ExecutionContext context, Map<String, Object> configuration) {
         AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(context, context.getFramework(), context.getNodes(), configuration);
-        return AnsibleUtil.getSecretsPath(builder);
+        return AnsibleUtil.getSecretsPathWorkflowSteps(builder);
     }
 
     @Override

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
@@ -70,6 +70,8 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         // Project and framework level mappings for inventory generation
         builder.mapping(ANSIBLE_GENERATE_INVENTORY, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
         builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
+        builder.mapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
+        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
 
         DESC = builder.build();
     }
@@ -107,11 +109,31 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
             runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
 
             Boolean generateInventoryNodeAuth = contextBuilder.generateInventoryNodesAuth();
+
+            boolean isDebug = context.getDataContext().get("job").get("loglevel").equals("DEBUG");
+
+            if(isDebug) {
+                System.err.println("DEBUG: generateInventoryNodesAuth returned: " + generateInventoryNodeAuth);
+            }
+
             if(generateInventoryNodeAuth != null && generateInventoryNodeAuth){
+                if(isDebug) {
+                    System.err.println("DEBUG: Node auth is enabled, getting authentication map");
+                }
                 Map<String, Map<String, String>> nodesAuth = contextBuilder.getNodesAuthenticationMap();
+                if(isDebug) {
+                    System.err.println("DEBUG: Retrieved " + (nodesAuth != null ? nodesAuth.size() : 0) + " node authentications");
+                }
                 if (nodesAuth != null && !nodesAuth.isEmpty()) {
                     runner.setAddNodeAuthToInventory(true);
                     runner.setNodesAuthentication(nodesAuth);
+                    if(isDebug) {
+                        System.err.println("DEBUG: Set node authentication on runner");
+                    }
+                }
+            } else {
+                if(isDebug) {
+                    System.err.println("DEBUG: Node auth is NOT enabled");
                 }
             }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
@@ -105,7 +105,6 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
                 configuration,
                 pluginGroup);
 
-
         try {
             runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
 
@@ -162,7 +161,7 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
 
     @Override
     public List<String> listSecretsPathWorkflowStep(ExecutionContext context, Map<String, Object> configuration) {
-        AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(context, context.getFramework(), context.getNodes(), configuration);
+        AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(context, context.getFramework(), context.getNodes(), configuration, pluginGroup);
         return AnsibleUtil.getSecretsPathWorkflowSteps(builder);
     }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
@@ -43,6 +43,8 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         builder.property(PLAYBOOK_INLINE_PROP);
         builder.property(EXTRA_VARS_PROP);
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
+        builder.property(GENERATE_INVENTORY_PROP);
+        builder.property(GENERATE_INVENTORY_NODES_AUTH);
         builder.property(INVENTORY_INLINE_PROP);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
@@ -48,7 +48,6 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         builder.property(EXTRA_VARS_PROP);
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
         builder.property(INVENTORY_INLINE_PROP);
-        builder.property(GENERATE_INVENTORY_PROP);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);
         builder.property(EXTRA_ATTRS_PROP);
@@ -66,12 +65,6 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         builder.property(BECOME_USER_PROP);
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
         builder.property(DISABLE_LIMIT_PROP);
-
-        // Project and framework level mappings for inventory generation
-        builder.mapping(ANSIBLE_GENERATE_INVENTORY, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
-        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
-        builder.mapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
-        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
 
         DESC = builder.build();
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
@@ -48,6 +48,7 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         builder.property(EXTRA_VARS_PROP);
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
         builder.property(INVENTORY_INLINE_PROP);
+        builder.property(GENERATE_INVENTORY_PROP);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);
         builder.property(EXTRA_ATTRS_PROP);
@@ -65,6 +66,12 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         builder.property(BECOME_USER_PROP);
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
         builder.property(DISABLE_LIMIT_PROP);
+
+        // Project and framework level mappings for inventory generation
+        builder.mapping(ANSIBLE_GENERATE_INVENTORY, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
+        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
+        builder.mapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
+        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
 
         DESC = builder.build();
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
@@ -70,8 +70,6 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
         // Project and framework level mappings for inventory generation
         builder.mapping(ANSIBLE_GENERATE_INVENTORY, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
         builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
-        builder.mapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
-        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
 
         DESC = builder.build();
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookInlineWorkflowStep.java
@@ -87,11 +87,7 @@ public class AnsiblePlaybookInlineWorkflowStep implements StepPlugin, AnsibleDes
             configuration.put(AnsibleDescribable.ANSIBLE_LIMIT, limit);
         }
         // set log level
-        String loglevel = null;
-        if (context.getDataContext() != null &&
-            context.getDataContext().get("job") != null) {
-            loglevel = context.getDataContext().get("job").get("loglevel");
-        }
+        String loglevel = AnsibleUtil.getJobLogLevel(context);
 
         if ("DEBUG".equals(loglevel)) {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG, "True");

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorflowNodeStep.java
@@ -76,7 +76,13 @@ public class AnsiblePlaybookWorflowNodeStep implements NodeStepPlugin, AnsibleDe
 
         configuration.put(AnsibleDescribable.ANSIBLE_LIMIT,entry.getNodename());
         // set log level
-        if (context.getDataContext().get("job").get("loglevel").equals("DEBUG")) {
+        String loglevel = null;
+        if (context.getDataContext() != null &&
+            context.getDataContext().get("job") != null) {
+            loglevel = context.getDataContext().get("job").get("loglevel");
+        }
+
+        if ("DEBUG".equals(loglevel)) {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"True");
         } else {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"False");

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorflowNodeStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorflowNodeStep.java
@@ -76,11 +76,7 @@ public class AnsiblePlaybookWorflowNodeStep implements NodeStepPlugin, AnsibleDe
 
         configuration.put(AnsibleDescribable.ANSIBLE_LIMIT,entry.getNodename());
         // set log level
-        String loglevel = null;
-        if (context.getDataContext() != null &&
-            context.getDataContext().get("job") != null) {
-            loglevel = context.getDataContext().get("job").get("loglevel");
-        }
+        String loglevel = AnsibleUtil.getJobLogLevel(context);
 
         if ("DEBUG".equals(loglevel)) {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG,"True");

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -85,11 +85,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
             configuration.put(AnsibleDescribable.ANSIBLE_LIMIT, limit);
         }
         // set log level
-        String loglevel = null;
-        if (context.getDataContext() != null &&
-            context.getDataContext().get("job") != null) {
-            loglevel = context.getDataContext().get("job").get("loglevel");
-        }
+        String loglevel = AnsibleUtil.getJobLogLevel(context);
 
         if ("DEBUG".equals(loglevel)) {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG, "True");

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -66,7 +66,6 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
         builder.property(DISABLE_LIMIT_PROP);
 
-
         DESC = builder.build();
     }
 
@@ -156,7 +155,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
 
     @Override
     public List<String> listSecretsPathWorkflowStep(ExecutionContext context, Map<String, Object> configuration) {
-        AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(context, context.getFramework(), context.getNodes(), configuration);
+        AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(context, context.getFramework(), context.getNodes(), configuration, pluginGroup);
         return AnsibleUtil.getSecretsPathWorkflowSteps(builder);
     }
     @Override

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -43,6 +43,8 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         builder.property(EXTRA_VARS_PROP);
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
         builder.property(INVENTORY_INLINE_PROP);
+        builder.property(GENERATE_INVENTORY_PROP);
+        builder.property(GENERATE_INVENTORY_NODES_AUTH);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);
         builder.property(EXTRA_ATTRS_PROP);
@@ -127,7 +129,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
     @Override
     public List<String> listSecretsPathWorkflowStep(ExecutionContext context, Map<String, Object> configuration) {
         AnsibleRunnerContextBuilder builder = new AnsibleRunnerContextBuilder(context, context.getFramework(), context.getNodes(), configuration);
-        return AnsibleUtil.getSecretsPath(builder);
+        return AnsibleUtil.getSecretsPathWorkflowSteps(builder);
     }
     @Override
     public Map<String, String> getRuntimeProperties(ExecutionContext context) {

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -16,11 +16,13 @@ import com.dtolabs.rundeck.plugins.step.PluginStepContext;
 import com.dtolabs.rundeck.plugins.step.StepPlugin;
 import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
 import com.rundeck.plugins.ansible.util.AnsibleUtil;
+import lombok.extern.slf4j.Slf4j;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+@Slf4j
 @Plugin(name = AnsiblePlaybookWorkflowStep.SERVICE_PROVIDER_NAME, service = ServiceNameConstants.WorkflowStep)
 public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribable, ProxyRunnerPlugin, ConfiguredBy<AnsiblePluginGroup> {
 
@@ -84,7 +86,13 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
             configuration.put(AnsibleDescribable.ANSIBLE_LIMIT, limit);
         }
         // set log level
-        if (context.getDataContext().get("job").get("loglevel").equals("DEBUG")) {
+        String loglevel = null;
+        if (context.getDataContext() != null &&
+            context.getDataContext().get("job") != null) {
+            loglevel = context.getDataContext().get("job").get("loglevel");
+        }
+
+        if ("DEBUG".equals(loglevel)) {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG, "True");
         } else {
             configuration.put(AnsibleDescribable.ANSIBLE_DEBUG, "False");
@@ -101,31 +109,19 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
 
             Boolean generateInventoryNodeAuth = contextBuilder.generateInventoryNodesAuth();
 
-            boolean isDebug = context.getDataContext().get("job").get("loglevel").equals("DEBUG");
-
-            if(isDebug) {
-                System.err.println("DEBUG: generateInventoryNodesAuth returned: " + generateInventoryNodeAuth);
-            }
+            log.debug("generateInventoryNodesAuth returned: {}", generateInventoryNodeAuth);
 
             if(generateInventoryNodeAuth != null && generateInventoryNodeAuth){
-                if(isDebug) {
-                    System.err.println("DEBUG: Node auth is enabled, getting authentication map");
-                }
+                log.debug("Node auth is enabled, getting authentication map");
                 Map<String, Map<String, String>> nodesAuth = contextBuilder.getNodesAuthenticationMap();
-                if(isDebug) {
-                    System.err.println("DEBUG: Retrieved " + (nodesAuth != null ? nodesAuth.size() : 0) + " node authentications");
-                }
+                log.debug("Retrieved {} node authentications", (nodesAuth != null ? nodesAuth.size() : 0));
                 if (nodesAuth != null && !nodesAuth.isEmpty()) {
                     runner.setAddNodeAuthToInventory(true);
                     runner.setNodesAuthentication(nodesAuth);
-                    if(isDebug) {
-                        System.err.println("DEBUG: Set node authentication on runner");
-                    }
+                    log.debug("Set node authentication on runner");
                 }
             } else {
-                if(isDebug) {
-                    System.err.println("DEBUG: Node auth is NOT enabled");
-                }
+                log.debug("Node auth is NOT enabled");
             }
 
             runner.setCustomTmpDirPath(AnsibleUtil.getCustomTmpPathDir(contextBuilder.getFramework()));

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -46,6 +46,7 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         builder.property(EXTRA_VARS_PROP);
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
         builder.property(INVENTORY_INLINE_PROP);
+        builder.property(GENERATE_INVENTORY_PROP);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);
         builder.property(EXTRA_ATTRS_PROP);
@@ -63,6 +64,12 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         builder.property(BECOME_USER_PROP);
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
         builder.property(DISABLE_LIMIT_PROP);
+
+        // Project and framework level mappings for inventory generation
+        builder.mapping(ANSIBLE_GENERATE_INVENTORY, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
+        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
+        builder.mapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
+        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
 
         DESC = builder.build();
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -46,7 +46,6 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         builder.property(EXTRA_VARS_PROP);
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
         builder.property(INVENTORY_INLINE_PROP);
-        builder.property(GENERATE_INVENTORY_PROP);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);
         builder.property(EXTRA_ATTRS_PROP);
@@ -65,11 +64,6 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         builder.property(BECOME_PASSWORD_STORAGE_PROP);
         builder.property(DISABLE_LIMIT_PROP);
 
-        // Project and framework level mappings for inventory generation
-        builder.mapping(ANSIBLE_GENERATE_INVENTORY, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
-        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
-        builder.mapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
-        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
 
         DESC = builder.build();
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -43,8 +43,6 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         builder.property(EXTRA_VARS_PROP);
         builder.property(CONFIG_ENCRYPT_EXTRA_VARS);
         builder.property(INVENTORY_INLINE_PROP);
-        builder.property(GENERATE_INVENTORY_PROP);
-        builder.property(GENERATE_INVENTORY_NODES_AUTH);
         builder.property(VAULT_KEY_FILE_PROP);
         builder.property(VAULT_KEY_STORAGE_PROP);
         builder.property(EXTRA_ATTRS_PROP);

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -68,8 +68,6 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         // Project and framework level mappings for inventory generation
         builder.mapping(ANSIBLE_GENERATE_INVENTORY, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
         builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
-        builder.mapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
-        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
 
         DESC = builder.build();
     }

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -36,7 +36,10 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         builder.name(SERVICE_PROVIDER_NAME);
         builder.title("Ansible Playbook");
         builder.description("Runs an Ansible Playbook.");
-
+        builder.metadata(
+                "automaticWorkflowStepRunnerAssociation",
+                "true"
+        );
         builder.property(BINARIES_DIR_PATH_PROP);
         builder.property(BASE_DIR_PROP);
         builder.property(PLAYBOOK_PATH_PROP);
@@ -94,6 +97,16 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
 
         try {
             runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
+
+            Boolean generateInventoryNodeAuth = contextBuilder.generateInventoryNodesAuth();
+            if(generateInventoryNodeAuth != null && generateInventoryNodeAuth){
+                Map<String, Map<String, String>> nodesAuth = contextBuilder.getNodesAuthenticationMap();
+                if (nodesAuth != null && !nodesAuth.isEmpty()) {
+                    runner.setAddNodeAuthToInventory(true);
+                    runner.setNodesAuthentication(nodesAuth);
+                }
+            }
+
             runner.setCustomTmpDirPath(AnsibleUtil.getCustomTmpPathDir(contextBuilder.getFramework()));
         } catch (ConfigurationException e) {
             throw new StepException("Error configuring Ansible runner: " + e.getMessage(), e, AnsibleException.AnsibleFailureReason.ParseArgumentsError);

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePlaybookWorkflowStep.java
@@ -68,6 +68,8 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
         // Project and framework level mappings for inventory generation
         builder.mapping(ANSIBLE_GENERATE_INVENTORY, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
         builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY);
+        builder.mapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, PROJ_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
+        builder.frameworkMapping(ANSIBLE_GENERATE_INVENTORY_NODES_AUTH, FWK_PROP_PREFIX + ANSIBLE_GENERATE_INVENTORY_NODES_AUTH);
 
         DESC = builder.build();
     }
@@ -104,11 +106,31 @@ public class AnsiblePlaybookWorkflowStep implements StepPlugin, AnsibleDescribab
             runner = AnsibleRunner.buildAnsibleRunner(contextBuilder);
 
             Boolean generateInventoryNodeAuth = contextBuilder.generateInventoryNodesAuth();
+
+            boolean isDebug = context.getDataContext().get("job").get("loglevel").equals("DEBUG");
+
+            if(isDebug) {
+                System.err.println("DEBUG: generateInventoryNodesAuth returned: " + generateInventoryNodeAuth);
+            }
+
             if(generateInventoryNodeAuth != null && generateInventoryNodeAuth){
+                if(isDebug) {
+                    System.err.println("DEBUG: Node auth is enabled, getting authentication map");
+                }
                 Map<String, Map<String, String>> nodesAuth = contextBuilder.getNodesAuthenticationMap();
+                if(isDebug) {
+                    System.err.println("DEBUG: Retrieved " + (nodesAuth != null ? nodesAuth.size() : 0) + " node authentications");
+                }
                 if (nodesAuth != null && !nodesAuth.isEmpty()) {
                     runner.setAddNodeAuthToInventory(true);
                     runner.setNodesAuthentication(nodesAuth);
+                    if(isDebug) {
+                        System.err.println("DEBUG: Set node authentication on runner");
+                    }
+                }
+            } else {
+                if(isDebug) {
+                    System.err.println("DEBUG: Node auth is NOT enabled");
                 }
             }
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePluginGroup.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePluginGroup.java
@@ -39,22 +39,6 @@ public class AnsiblePluginGroup implements PluginGroup, Describable {
         this.encryptExtraVars = encryptExtraVars;
     }
 
-    public Boolean getGenerateInventory() {
-        return generateInventory;
-    }
-
-    public void setGenerateInventory(Boolean generateInventory) {
-        this.generateInventory = generateInventory;
-    }
-
-    public Boolean getGenerateInventoryNodesAuth() {
-        return generateInventoryNodesAuth;
-    }
-
-    public void setGenerateInventoryNodesAuth(Boolean generateInventoryNodesAuth) {
-        this.generateInventoryNodesAuth = generateInventoryNodesAuth;
-    }
-
     @PluginProperty(
             title = "Ansible config file path",
             description = "Set ansible config file path."
@@ -72,18 +56,6 @@ public class AnsiblePluginGroup implements PluginGroup, Describable {
             description = "Encrypt the value of the extra vars keys."
     )
     Boolean encryptExtraVars;
-
-    @PluginProperty(
-            title = "Generate inventory",
-            description = "Generate an Ansible inventory from the targeted nodes."
-    )
-    Boolean generateInventory;
-
-    @PluginProperty(
-            title = "Generate inventory with node authentication",
-            description = "Add node-specific authentication credentials to the generated inventory via group_vars."
-    )
-    Boolean generateInventoryNodesAuth;
 
     @Override
     public Description getDescription() {

--- a/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePluginGroup.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/plugin/AnsiblePluginGroup.java
@@ -39,6 +39,22 @@ public class AnsiblePluginGroup implements PluginGroup, Describable {
         this.encryptExtraVars = encryptExtraVars;
     }
 
+    public Boolean getGenerateInventory() {
+        return generateInventory;
+    }
+
+    public void setGenerateInventory(Boolean generateInventory) {
+        this.generateInventory = generateInventory;
+    }
+
+    public Boolean getGenerateInventoryNodesAuth() {
+        return generateInventoryNodesAuth;
+    }
+
+    public void setGenerateInventoryNodesAuth(Boolean generateInventoryNodesAuth) {
+        this.generateInventoryNodesAuth = generateInventoryNodesAuth;
+    }
+
     @PluginProperty(
             title = "Ansible config file path",
             description = "Set ansible config file path."
@@ -56,6 +72,18 @@ public class AnsiblePluginGroup implements PluginGroup, Describable {
             description = "Encrypt the value of the extra vars keys."
     )
     Boolean encryptExtraVars;
+
+    @PluginProperty(
+            title = "Generate inventory",
+            description = "Generate an Ansible inventory from the targeted nodes."
+    )
+    Boolean generateInventory;
+
+    @PluginProperty(
+            title = "Generate inventory with node authentication",
+            description = "Add node-specific authentication credentials to the generated inventory via group_vars."
+    )
+    Boolean generateInventoryNodesAuth;
 
     @Override
     public Description getDescription() {

--- a/src/main/groovy/com/rundeck/plugins/ansible/util/AnsibleUtil.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/util/AnsibleUtil.java
@@ -86,6 +86,16 @@ public class AnsibleUtil {
 
     }
 
+    public static List<String> getSecretsPathWorkflowSteps(AnsibleRunnerContextBuilder builder){
+        List<String> secretPaths = getSecretsPath(builder);
+        List<String> secretPathsNodes =builder.getListNodesKeyPath();
+
+        if(secretPathsNodes!=null && !secretPathsNodes.isEmpty()){
+            secretPaths.addAll(secretPathsNodes);
+        }
+        return secretPaths;
+    }
+
     public static Map<String, String> getRuntimeProperties(ExecutionContext context, String propertyPrefix) {
         Map<String, String> properties = null;
 

--- a/src/main/groovy/com/rundeck/plugins/ansible/util/AnsibleUtil.java
+++ b/src/main/groovy/com/rundeck/plugins/ansible/util/AnsibleUtil.java
@@ -140,5 +140,31 @@ public class AnsibleUtil {
         return  customTmpDir;
     }
 
+    /**
+     * Safely retrieves the loglevel from the execution context's data context.
+     * Returns null if the loglevel cannot be retrieved (e.g., if data context or job is null).
+     *
+     * @param context The execution context
+     * @return The loglevel string, or null if not available
+     */
+    public static String getJobLogLevel(ExecutionContext context) {
+        if (context.getDataContext() != null &&
+            context.getDataContext().get("job") != null) {
+            return context.getDataContext().get("job").get("loglevel");
+        }
+        return null;
+    }
+
+    /**
+     * Safely retrieves the loglevel from the plugin step context's data context.
+     * Returns null if the loglevel cannot be retrieved (e.g., if data context or job is null).
+     *
+     * @param context The plugin step context
+     * @return The loglevel string, or null if not available
+     */
+    public static String getJobLogLevel(PluginStepContext context) {
+        return getJobLogLevel(context.getExecutionContext());
+    }
+
 
 }

--- a/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
@@ -670,7 +670,7 @@ class AnsibleRunnerSpec extends Specification{
         "not a vault"                                 || false
         null                                          || false
         ""                                            || false
-        "!vault"                                      || true  // minimal valid
+        "!vault"                                      || false // single-line without content - invalid
         "!vault |\n"                                  || false // no content
     }
 
@@ -759,7 +759,9 @@ class AnsibleRunnerSpec extends Specification{
 
         then:
         !yaml.contains("host_passwords:")  // Should not appear when empty
-        yaml.contains("host_users:")
+        !yaml.contains("host_users:")  // Should not appear when empty
+        !yaml.contains("host_private_keys:")  // Should not appear when empty
+        yaml.isEmpty() || yaml.trim().isEmpty()  // Should produce empty or whitespace-only output
     }
 
     def "escapePasswordForYaml: should escape special characters"() {

--- a/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
@@ -620,7 +620,7 @@ class AnsibleRunnerSpec extends Specification{
         "-starts-with-dash"  || "\"-starts-with-dash\""
         "?starts-with-q"     || "\"?starts-with-q\""
         "123numeric"         || "\"123numeric\""
-        "key with spaces"    || "key with spaces"  // spaces are handled differently
+        "key with spaces"    || "key with spaces"  // spaces are valid in unquoted YAML keys, so we intentionally do not quote them
     }
 
     def "escapeYamlValue: should quote values with special characters"() {

--- a/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
@@ -666,7 +666,7 @@ class AnsibleRunnerSpec extends Specification{
         vaultValue                                    || expectedResult
         "!vault |\n  encryptedcontent"                || true
         "!vault |\n  line1\n  line2"                  || true
-        "!vault\n  content"                           || true  // without pipe
+        "!vault\n  content"                           || false // missing pipe - Ansible Vault always requires "|" for literal block style
         "not a vault"                                 || false
         null                                          || false
         ""                                            || false

--- a/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
@@ -690,7 +690,7 @@ class AnsibleRunnerSpec extends Specification{
         ]
 
         when:
-        def yaml = runner.buildGroupVarsYaml(hostPasswords, hostUsers)
+        def yaml = runner.buildGroupVarsYaml(hostPasswords, hostUsers, [:])
 
         then:
         yaml.contains("host_passwords:")
@@ -717,7 +717,7 @@ class AnsibleRunnerSpec extends Specification{
         ]
 
         when:
-        def yaml = runner.buildGroupVarsYaml(hostPasswords, hostUsers)
+        def yaml = runner.buildGroupVarsYaml(hostPasswords, hostUsers, [:])
 
         then:
         yaml.contains('"web:server:1": !vault |')
@@ -738,7 +738,7 @@ class AnsibleRunnerSpec extends Specification{
         ]
 
         when:
-        runner.buildGroupVarsYaml(hostPasswords, hostUsers)
+        runner.buildGroupVarsYaml(hostPasswords, hostUsers, [:])
 
         then:
         def e = thrown(RuntimeException)
@@ -755,10 +755,10 @@ class AnsibleRunnerSpec extends Specification{
         def hostUsers = [:]
 
         when:
-        def yaml = runner.buildGroupVarsYaml(hostPasswords, hostUsers)
+        def yaml = runner.buildGroupVarsYaml(hostPasswords, hostUsers, [:])
 
         then:
-        yaml.contains("host_passwords:")
+        !yaml.contains("host_passwords:")  // Should not appear when empty
         yaml.contains("host_users:")
     }
 

--- a/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
@@ -623,6 +623,24 @@ class AnsibleRunnerSpec extends Specification{
         "key with spaces"    || "key with spaces"  // internal spaces are valid in unquoted YAML keys; node names with leading/trailing spaces are not supported
     }
 
+    def "escapeYamlKey: node names with leading/trailing spaces are not modified"() {
+        given:
+        def builder = AnsibleRunner.playbookInline("test")
+        builder.customTmpDirPath("/tmp")
+        def runner = builder.build()
+
+        expect:
+        // This documents that escapeYamlKey does not normalize leading/trailing spaces.
+        // Node names with such spaces are considered unsupported at a higher level.
+        runner.escapeYamlKey(key) == expectedResult
+
+        where:
+        key                    || expectedResult
+        " leading-space"       || " leading-space"
+        "trailing-space "      || "trailing-space "
+        "  both-sides  "       || "  both-sides  "
+    }
+
     def "escapeYamlValue: should quote values with special characters"() {
         given:
         def builder = AnsibleRunner.playbookInline("test")

--- a/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
+++ b/src/test/groovy/com/rundeck/plugins/ansible/ansible/AnsibleRunnerSpec.groovy
@@ -1007,12 +1007,9 @@ class AnsibleRunnerSpec extends Specification{
     def "node name sanitization: should sanitize node names with forward slashes for temp files"() {
         given:
         // Test case from real issue: node name with forward slashes
+        def runner = AnsibleRunner.playbookInline("test").build()
         String nodeName = "/docker-runner-ansible-ssh-node-b-3"
-        String sanitized = nodeName.replaceAll("[^a-zA-Z0-9._-]", "_")
-        // Prevent hidden files (starting with .) and problematic names (empty or all dots)
-        if (sanitized.isEmpty() || sanitized.startsWith(".") || sanitized.matches(/^\.\+$/)) {
-            sanitized = "_" + sanitized
-        }
+        String sanitized = runner.sanitizeNodeNameForFilesystem(nodeName)
 
         expect:
         sanitized == "_docker-runner-ansible-ssh-node-b-3"
@@ -1022,11 +1019,8 @@ class AnsibleRunnerSpec extends Specification{
 
     def "node name sanitization: should sanitize various special characters"() {
         given:
-        String sanitized = nodeName.replaceAll("[^a-zA-Z0-9._-]", "_")
-        // Prevent hidden files (starting with .) and problematic names (empty or all dots)
-        if (sanitized.isEmpty() || sanitized.startsWith(".") || sanitized.matches(/^\.\+$/)) {
-            sanitized = "_" + sanitized
-        }
+        def runner = AnsibleRunner.playbookInline("test").build()
+        String sanitized = runner.sanitizeNodeNameForFilesystem(nodeName)
 
         expect:
         sanitized == expected
@@ -1050,12 +1044,9 @@ class AnsibleRunnerSpec extends Specification{
 
     def "node name sanitization: should preserve safe alphanumeric and allowed characters"() {
         given:
+        def runner = AnsibleRunner.playbookInline("test").build()
         String safeName = "my-node_123.server-A"
-        String sanitized = safeName.replaceAll("[^a-zA-Z0-9._-]", "_")
-        // Prevent hidden files (starting with .) and problematic names (empty or all dots)
-        if (sanitized.isEmpty() || sanitized.startsWith(".") || sanitized.matches(/^\.\+$/)) {
-            sanitized = "_" + sanitized
-        }
+        String sanitized = runner.sanitizeNodeNameForFilesystem(safeName)
 
         expect:
         sanitized == safeName  // Should not be changed
@@ -1063,11 +1054,8 @@ class AnsibleRunnerSpec extends Specification{
 
     def "node name sanitization: should handle empty and edge case node names"() {
         given:
-        String sanitized = nodeName.replaceAll("[^a-zA-Z0-9._-]", "_")
-        // Prevent hidden files (starting with .) and problematic names (empty or all dots)
-        if (sanitized.isEmpty() || sanitized.startsWith(".") || sanitized.matches(/^\.\+$/)) {
-            sanitized = "_" + sanitized
-        }
+        def runner = AnsibleRunner.playbookInline("test").build()
+        String sanitized = runner.sanitizeNodeNameForFilesystem(nodeName)
 
         expect:
         sanitized == expected


### PR DESCRIPTION
This pull request introduces comprehensive functional tests for the Ansible plugin's multi-node authentication feature, ensuring that each node can have its own credentials (password or private key) stored in Rundeck's key storage. It adds new test suites, supporting documentation, and Docker configurations to validate scenarios including password escaping, per-node authentication, and compatibility with current Rundeck versions.

**Key changes include:**

**1. Functional Test Coverage for Multi-Node Authentication**
- Added `MultiNodeAuthSpec.groovy`, a Spock test suite that verifies multi-node authentication with different credentials per node (passwords and private keys), password escaping for special characters, and node accessibility. The suite includes helper methods for project setup, key storage, and job execution.

**2. Test Documentation and Usage Instructions**
- Introduced a detailed `functional-test/README.md` explaining prerequisites, Docker/Testcontainers setup, how to run tests, test structure, troubleshooting, and specifics of the multi-node authentication feature.
- Added a scenario-specific README in `docker/ansible-multi-node-auth/README.md` describing the test setup, what is being tested, and expected behaviors.

**3. Docker and Test Resource Enhancements**
- Updated `docker-compose.yml` to add three new SSH test nodes (`ssh-node-2`, `ssh-node-3`, `ssh-node-4`) with unique passwords and private key authentication, and mounted the new test scenario directory. [[1]](diffhunk://#diff-4069a728bdaecee59b0729d2b7948e490f3154847867ea0843fe6e7c0cd84c4cR16-R51) [[2]](diffhunk://#diff-4069a728bdaecee59b0729d2b7948e490f3154847867ea0843fe6e7c0cd84c4cR76)
- Added Ansible configuration (`ansible.cfg`), inventory (`inventory.ini`), node definitions (`resources.xml`), and a test playbook (`test-playbook.yml`) for the multi-node authentication scenario. [[1]](diffhunk://#diff-e8454f913a1f08fa566580e4a48cd6057a820c2f00cd42af9a21cc20412d2413R1-R8) [[2]](diffhunk://#diff-6625ac1f47c4819811202338d464822c44c72da0371ecead3c07b0f9ec05fabeR1-R8) [[3]](diffhunk://#diff-2e449cf03aa8888f71d210e082d4e8d7bd0ca8740719eb262c10667a59797d0dR1-R54) [[4]](diffhunk://#diff-60d50345637982b19e615d6e815b6807d3e12f489984f160e9544309077676cdR1-R39)

**4. Gradle and Test Environment Updates**
- Updated the functional test Gradle task to use Rundeck version 5.18.0 for compatibility testing and added comments about Docker/Testcontainers configuration.

These changes collectively provide robust, automated validation for the Ansible plugin's advanced authentication features, improving confidence in multi-node and mixed-auth scenarios.Generate Inventory with SSH password authentication