### PR TITLE
RUN-4166: Update Jackson for CWE-770

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ kotlin-stdlib = "2.1.0"
 
 # Current dependency versions (maintained for compatibility)
 gson = "2.10.1"
-jackson = "2.16.1"
+jackson = "2.18.6"
 snakeyaml = "2.2"
 groovy = "3.0.15"
 lombok = "1.18.30"


### PR DESCRIPTION
Update Jackson for CWE-770 to version 2.18.6