### PR TITLE
[RUN-4430] : increase actions version

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,7 +15,7 @@ jobs:
         run: git -c protocol.version=2 fetch --tags --progress --no-recurse-submodules origin
         if: "!contains(github.ref, 'refs/tags')"
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 17
           distribution: 'zulu'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Get Fetch Tags
@@ -33,7 +33,7 @@ jobs:
         id: get_version
         run: VERSION=$(./gradlew currentVersion -q -Prelease.quiet) && echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
       - name: Upload plugin jar
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           # Artifact name
           name: Grails-Plugin-${{ steps.get_version.outputs.VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '17'
           distribution: 'zulu'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow files to use the latest major versions of key GitHub Actions. The main focus is on keeping the CI/CD pipeline up-to-date and secure by upgrading the action versions.

**GitHub Actions version upgrades:**
- Upgraded `actions/checkout` from `v4` to `v5` in both `.github/workflows/gradle.yml` and `.github/workflows/release.yml` to use the latest improvements and bug fixes. [[1]](diffhunk://#diff-0d634959c8276ae976e39ba475e63d0b9ec27824470c79f1971f58fe37c46325L11-R18) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L14-R18)
- Upgraded `actions/setup-java` from `v4` to `v5` in both workflow files to ensure compatibility and leverage new features for Java setup. [[1]](diffhunk://#diff-0d634959c8276ae976e39ba475e63d0b9ec27824470c79f1971f58fe37c46325L11-R18) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L14-R18)
- Upgraded `actions/upload-artifact` from `v4` to `v5` in `.github/workflows/gradle.yml` for improved artifact handling and reliability.